### PR TITLE
librispeech get_bliss_corpus_dict small fix

### DIFF
--- a/common/datasets/librispeech.py
+++ b/common/datasets/librispeech.py
@@ -86,11 +86,7 @@ def get_bliss_corpus_dict(audio_format="flac", subdir_prefix=""):
     """
     assert audio_format in ["flac", "ogg", "wav"]
 
-    subdir_prefix = (
-        os.path.join(subdir_prefix, "LibriSpeech")
-        if subdir_prefix
-        else None
-    )
+    subdir_prefix = os.path.join(subdir_prefix, "LibriSpeech")
 
     download_metadata_job = DownloadLibriSpeechMetadataJob()
     download_metadata_job.add_alias(


### PR DESCRIPTION
In the default case, `subdir_prefix` is set to `None` and later used in `os.path.join()`, which does not work.