### PR TITLE
allow for g2p augmented Librispeech lexicon with stress markers

### DIFF
--- a/common/datasets/librispeech.py
+++ b/common/datasets/librispeech.py
@@ -399,6 +399,7 @@ def get_g2p_augmented_bliss_lexicon_dict(use_stress_marker=False, subdir_prefix=
     out of vocabulary (OOV) words for each of the LibriSpeech training corpora. Here, we create a dictionary
     that has different train corpora as keys and the corresponding g2p augmented bliss lexicon as values
 
+    :param bool use_stress_marker: uses phonem symbols with stress markers
     :param str subdir_prefix:
     :return: dictionary of Paths to augmented bliss_lexicon
     :rtype: dict[str, Path]

--- a/common/datasets/librispeech.py
+++ b/common/datasets/librispeech.py
@@ -393,7 +393,7 @@ def get_bliss_lexicon(use_stress_marker=False, subdir_prefix=""):
     return merge_lexicon_job.out_bliss_lexicon
 
 
-def get_g2p_augmented_bliss_lexicon_dict(subdir_prefix=""):
+def get_g2p_augmented_bliss_lexicon_dict(use_stress_marker=False, subdir_prefix=""):
     """
     Given the original LibriSpeech bliss lexicon, it is possible to estimate the pronunciation for
     out of vocabulary (OOV) words for each of the LibriSpeech training corpora. Here, we create a dictionary
@@ -406,7 +406,9 @@ def get_g2p_augmented_bliss_lexicon_dict(subdir_prefix=""):
     alias_path = os.path.join(subdir_prefix, "LibriSpeech", "lexicon")
     augmented_bliss_lexica = {}
 
-    original_bliss_lexicon = get_bliss_lexicon(subdir_prefix=subdir_prefix)
+    original_bliss_lexicon = get_bliss_lexicon(
+        use_stress_marker=use_stress_marker, subdir_prefix=subdir_prefix
+    )
     g2p_augmenter = G2PBasedOovAugmenter(original_bliss_lexicon=original_bliss_lexicon)
 
     bliss_corpus_dict = get_bliss_corpus_dict(subdir_prefix=subdir_prefix)

--- a/common/datasets/librispeech.py
+++ b/common/datasets/librispeech.py
@@ -399,7 +399,7 @@ def get_g2p_augmented_bliss_lexicon_dict(use_stress_marker=False, subdir_prefix=
     out of vocabulary (OOV) words for each of the LibriSpeech training corpora. Here, we create a dictionary
     that has different train corpora as keys and the corresponding g2p augmented bliss lexicon as values
 
-    :param bool use_stress_marker: uses phonem symbols with stress markers
+    :param bool use_stress_marker: uses phoneme symbols with stress markers
     :param str subdir_prefix:
     :return: dictionary of Paths to augmented bliss_lexicon
     :rtype: dict[str, Path]


### PR DESCRIPTION
This adds the option to use stress markers while g2p augmenting the librispeech lexicon if one so desires.