### PR TITLE
base g2p augmented lexicon for larger corpora on prev. lexicon

### DIFF
--- a/common/datasets/librispeech.py
+++ b/common/datasets/librispeech.py
@@ -410,18 +410,21 @@ def get_g2p_augmented_bliss_lexicon_dict(use_stress_marker=False, subdir_prefix=
     original_bliss_lexicon = get_bliss_lexicon(
         use_stress_marker=use_stress_marker, subdir_prefix=subdir_prefix
     )
-    g2p_augmenter = G2PBasedOovAugmenter(original_bliss_lexicon=original_bliss_lexicon)
+    current_bliss_lexicon = original_bliss_lexicon
 
     bliss_corpus_dict = get_bliss_corpus_dict(subdir_prefix=subdir_prefix)
-    for corpus_name, bliss_corpus in bliss_corpus_dict.items():
+    for corpus_name, bliss_corpus in sorted(bliss_corpus_dict.items()):
         if "train" in corpus_name:
-            augmented_bliss_lexica[
-                corpus_name
-            ] = g2p_augmenter.get_g2p_augmented_bliss_lexicon(
+            g2p_augmenter = G2PBasedOovAugmenter(
+                original_bliss_lexicon=updated_bliss_lexicon,
+                train_lexicon=original_bliss_lexicon,
+            )
+            current_bliss_lexicon = g2p_augmenter.get_g2p_augmented_bliss_lexicon(
                 bliss_corpus=bliss_corpus,
                 corpus_name=corpus_name,
                 alias_path=alias_path,
             )
+            augmented_bliss_lexica[corpus_name] = current_bliss_lexicon
 
     return augmented_bliss_lexica
 

--- a/common/datasets/librispeech.py
+++ b/common/datasets/librispeech.py
@@ -415,16 +415,19 @@ def get_g2p_augmented_bliss_lexicon_dict(use_stress_marker=False, subdir_prefix=
     bliss_corpus_dict = get_bliss_corpus_dict(subdir_prefix=subdir_prefix)
     for corpus_name, bliss_corpus in sorted(bliss_corpus_dict.items()):
         if "train" in corpus_name:
-            g2p_augmenter = G2PBasedOovAugmenter(
-                original_bliss_lexicon=updated_bliss_lexicon,
-                train_lexicon=original_bliss_lexicon,
-            )
-            current_bliss_lexicon = g2p_augmenter.get_g2p_augmented_bliss_lexicon(
-                bliss_corpus=bliss_corpus,
-                corpus_name=corpus_name,
-                alias_path=alias_path,
-            )
-            augmented_bliss_lexica[corpus_name] = current_bliss_lexicon
+            if corpus_name in ["train-clean-460", "train-other-960"]:
+                augmented_bliss_lexica[corpus_name] = current_bliss_lexicon
+            else:
+                g2p_augmenter = G2PBasedOovAugmenter(
+                    original_bliss_lexicon=current_bliss_lexicon,
+                    train_lexicon=original_bliss_lexicon,
+                )
+                current_bliss_lexicon = g2p_augmenter.get_g2p_augmented_bliss_lexicon(
+                    bliss_corpus=bliss_corpus,
+                    corpus_name=corpus_name,
+                    alias_path=alias_path,
+                )
+                augmented_bliss_lexica[corpus_name] = current_bliss_lexicon
 
     return augmented_bliss_lexica
 


### PR DESCRIPTION
This implements my suggestion from https://github.com/rwth-i6/i6_experiments/pull/15


We would use the initial lexicon to train the (all) g2p models and then for each corpus the lexicon is continuously extended by the next larger corpus' OOVs. The order will be alphabetically i.e. "train-clean-100"->"train-clean-360"->"train-other-500"

Advantages:
 * we save a little bit of computational effort on shared OOVs
 * we will be able to use the 100h alignment as input for training jobs of larger corpora. (e.g. GMM Pipeline: monophone -> 100h, triphone->460h, triphone->960h)

Disadvantages:
 * if we wanted to do 360h-only training, then a few unnecessary 100h OOV words would be added.