### PR TITLE
Fairseq hydra training job

### DIFF
--- a/users/engler/fairseq/training.py
+++ b/users/engler/fairseq/training.py
@@ -1,0 +1,97 @@
+import os
+import subprocess as sp
+import yaml
+
+from sisyphus import *
+
+import recipe.i6_core.util as util
+
+
+class DictToYamlJob(Job):
+    """
+    Writes a dict into a .yaml file
+    """
+
+    def __init__(self, config_dict, hash_reset, *, yaml_prefix=""):
+        """
+        :param dict config_dict:
+        :param str hash_reset: Temporary way to reset the sisyphus hash for debugging purposes
+        :param str yaml_prefix: Prefix which should be written to the beginning, for example "# @package _group_" or "#!rnn.py"
+        """
+        assert isinstance(config_dict, dict)
+
+        self.config_dict = config_dict
+        self.yaml_prefix = yaml_prefix
+        self.out_config_file = self.output_path("fairseq_config.yaml")
+        self.file_out = self.output_path("out")
+
+    def tasks(self):
+        yield Task("run", mini_task=True)
+
+    def run(self):
+        yaml_dict = yaml.dump(self.config_dict)
+        # "# @package _group_" was written at the beginning in the example .yaml from fairseq:
+        if self.yaml_prefix != "":
+            yaml_dict = self.yaml_prefix + "\n" + yaml_dict
+        with open(self.out_config_file.get_path(), "w") as file:
+            file.write(yaml_dict)
+
+
+class FairseqHydraTrainingJob(Job):
+    """
+    Train a Fairseq model using fairseq-hydra-train
+    """
+
+    def __init__(
+        self,
+        python_exe,
+        fairseq_exe,
+        hash_reset,
+        *,  # args below are keyword only
+        additional_args=[],
+        time_rqmt=4,
+        mem_rqmt=4,
+        cpu_rqmt=2,
+        gpu_rqmt=1,
+    ):
+        """
+        :param Path|str python_exe: File path to the executable for running python
+        :param Path|str fairseq_exe: File path to the Fairseq executable: fairseq-hydra-train (usually in the same folder as python exe '.../bin/')
+        :param str hash_reset: temporary way to reset the sisyphus hash for debugging purposes
+        :param list additional_args: The arguments needed to configure the Fairseq task
+        :param int|float time_rqmt:
+        :param int|float mem_rqmt:
+        :param int cpu_rqmt:
+        :param int gpu_rqmt:
+        """
+        self.fairseq_python_exe = python_exe
+        self.fairseq_train = fairseq_exe
+        self.additional_args = additional_args
+        self.checkpoint_dir = self.output_path("checkpoints")
+        self.file_out = self.output_path("out")
+
+        self.rqmt = {
+            "gpu": gpu_rqmt,
+            "cpu": cpu_rqmt,
+            "mem": mem_rqmt,
+            "time": time_rqmt,
+        }
+
+    def tasks(self):
+        yield Task("create_files", mini_task=True)
+        yield Task("run", resume="run", rqmt=self.rqmt)
+
+    def _get_run_cmd(self):
+        run_cmd = [
+            tk.uncached_path(self.fairseq_python_exe),
+            tk.uncached_path(self.fairseq_train),
+        ]
+        run_cmd += self.additional_args
+        run_cmd += ["checkpoint.save_dir=" + str(self.checkpoint_dir)]
+        return run_cmd
+
+    def create_files(self):
+        util.create_executable("fairseq.sh", self._get_run_cmd())
+
+    def run(self):
+        sp.check_call(self._get_run_cmd())

--- a/users/engler/fairseq/training.py
+++ b/users/engler/fairseq/training.py
@@ -7,33 +7,26 @@ from sisyphus import *
 import recipe.i6_core.util as util
 
 
-class DictToYamlJob(Job):
+class FairseqHydraConfig:
     """
-    Writes a dict into a .yaml file
+    An object that manages a Fairseq hydra config (inspired by the ReturnnConfig).
     """
 
-    def __init__(self, config_dict, hash_reset, *, yaml_prefix=""):
+    def __init__(self, fairseq_hydra_config_dict, *, yaml_prefix=""):
         """
-        :param dict config_dict:
-        :param str hash_reset: Temporary way to reset the sisyphus hash for debugging purposes
-        :param str yaml_prefix: Prefix which should be written to the beginning, for example "# @package _group_" or "#!rnn.py"
+        :param dict fairseq_hydra_config_dict: Contains the information which is needed for fairseq-hydra-train. Will be converted and dumped into a .yaml
+        :param str yaml_prefix: Prefix which should be written to the beginning of the config, for example "# @package _group_"
         """
-        assert isinstance(config_dict, dict)
-
-        self.config_dict = config_dict
+        assert isinstance(fairseq_hydra_config_dict, dict)
+        self.fairseq_hydra_config_dict = fairseq_hydra_config_dict
         self.yaml_prefix = yaml_prefix
-        self.out_config_file = self.output_path("fairseq_config.yaml")
-        self.file_out = self.output_path("out")
 
-    def tasks(self):
-        yield Task("run", mini_task=True)
-
-    def run(self):
-        yaml_dict = yaml.dump(self.config_dict)
+    def write(self, path):
+        yaml_dict = yaml.dump(self.fairseq_hydra_config_dict)
         # "# @package _group_" was written at the beginning in the example .yaml from fairseq:
         if self.yaml_prefix != "":
             yaml_dict = self.yaml_prefix + "\n" + yaml_dict
-        with open(self.out_config_file.get_path(), "w") as file:
+        with open(path, "w") as file:
             file.write(yaml_dict)
 
 
@@ -44,31 +37,41 @@ class FairseqHydraTrainingJob(Job):
 
     def __init__(
         self,
-        python_exe,
-        fairseq_exe,
-        hash_reset,
+        fairseq_hydra_config,
         *,  # args below are keyword only
-        additional_args=[],
+        command_line_args=None,
         time_rqmt=4,
         mem_rqmt=4,
         cpu_rqmt=2,
         gpu_rqmt=1,
+        fairseq_python_exe=None,
+        fairseq_hydra_exe=None,
     ):
         """
+        :param FairseqHydraConfig fairseq_hydra_config:
+        :param list command_line_args: The command line arguments needed to configure the Fairseq-hydra task ('--config-dir' and '--config-name' are already taken care of)
+        :param int|float time_rqmt: Overall time requirements
+        :param int|float mem_rqmt: Memory requirements (per GPU)
+        :param int cpu_rqmt: Required number of CPUs (per GPU)
+        :param int gpu_rqmt: Number of required GPUs
         :param Path|str python_exe: File path to the executable for running python
-        :param Path|str fairseq_exe: File path to the Fairseq executable: fairseq-hydra-train (usually in the same folder as python exe '.../bin/')
-        :param str hash_reset: temporary way to reset the sisyphus hash for debugging purposes
-        :param list additional_args: The arguments needed to configure the Fairseq task
-        :param int|float time_rqmt:
-        :param int|float mem_rqmt:
-        :param int cpu_rqmt:
-        :param int gpu_rqmt:
+        :param Path|str fairseq_hydra_exe: File path to the Fairseq executable: fairseq-hydra-train (usually in the same folder as python exe '.../bin/')
+
         """
-        self.fairseq_python_exe = python_exe
-        self.fairseq_train = fairseq_exe
-        self.additional_args = additional_args
-        self.checkpoint_dir = self.output_path("checkpoints")
-        self.file_out = self.output_path("out")
+        self.fairseq_hydra_config = fairseq_hydra_config
+        self.command_line_args = command_line_args or []
+        self.yaml_config_name = "fairseq_hydra_config.yaml"
+        self.out_fairseq_hydra_yaml = self.output_path(self.yaml_config_name)
+        self.out_checkpoint_dir = self.output_path("checkpoints")
+        self.gpu_rqmt = gpu_rqmt
+        self.fairseq_python_exe = (
+            fairseq_python_exe
+            if fairseq_python_exe is not None
+            else gs.FAIRSEQ_PYTHON_EXE
+        )
+        self.fairseq_hydra_exe = (
+            fairseq_hydra_exe if fairseq_hydra_exe is not None else gs.FAIRSEQ_HYDRA_EXE
+        )
 
         self.rqmt = {
             "gpu": gpu_rqmt,
@@ -77,6 +80,10 @@ class FairseqHydraTrainingJob(Job):
             "time": time_rqmt,
         }
 
+        if self.gpu_rqmt > 1:
+            self.rqmt["cpu"] *= self.gpu_rqmt
+            self.rqmt["mem"] *= self.gpu_rqmt
+
     def tasks(self):
         yield Task("create_files", mini_task=True)
         yield Task("run", resume="run", rqmt=self.rqmt)
@@ -84,13 +91,18 @@ class FairseqHydraTrainingJob(Job):
     def _get_run_cmd(self):
         run_cmd = [
             tk.uncached_path(self.fairseq_python_exe),
-            tk.uncached_path(self.fairseq_train),
+            tk.uncached_path(self.fairseq_hydra_exe),
+            "--config-dir",
+            tk.uncached_path(self.output_path("")),
+            "--config-name",
+            self.yaml_config_name,
         ]
-        run_cmd += self.additional_args
-        run_cmd += ["checkpoint.save_dir=" + str(self.checkpoint_dir)]
+        run_cmd += self.command_line_args
+        run_cmd += ["checkpoint.save_dir=" + str(self.out_checkpoint_dir)]
         return run_cmd
 
     def create_files(self):
+        self.fairseq_hydra_config.write(self.out_fairseq_hydra_yaml.get_path())
         util.create_executable("fairseq.sh", self._get_run_cmd())
 
     def run(self):


### PR DESCRIPTION
Sisyphus job which starts a "fairseq-hydra-train" training for a given .yaml config data and (optional) command line arguments. 
The checkpoint directory is moved into the output folder of the job for re-starting the job.