### PR TITLE
adapt to new Lemma interface

### DIFF
--- a/common/datasets/librispeech.py
+++ b/common/datasets/librispeech.py
@@ -318,24 +318,22 @@ def get_special_lemma_lexicon():
         lexicon.Lemma(
             orth=["[SILENCE]", ""],
             phon=["[SILENCE]"],
-            synt=[[]],
+            synt=[],
             special="silence",
             eval=[[]],
         )
     )
     lex.add_lemma(
-        lexicon.Lemma(
-            orth=["[SENTENCE-BEGIN]"], synt=[["<s>"]], special="sentence-begin"
-        )
+        lexicon.Lemma(orth=["[SENTENCE-BEGIN]"], synt=["<s>"], special="sentence-begin")
     )
     lex.add_lemma(
-        lexicon.Lemma(orth=["[SENTENCE-END]"], synt=[["</s>"]], special="sentence-end")
+        lexicon.Lemma(orth=["[SENTENCE-END]"], synt=["</s>"], special="sentence-end")
     )
     lex.add_lemma(
         lexicon.Lemma(
             orth=["[UNKNOWN]"],
             phon=["[UNKNOWN]"],
-            synt=[["<UNK>"]],
+            synt=["<UNK>"],
             special="unknown",
         )
     )

--- a/common/datasets/switchboard.py
+++ b/common/datasets/switchboard.py
@@ -74,7 +74,7 @@ def get_special_lemma_lexicon():
             lexicon.Lemma(
                 orth=[tag],
                 phon=[tag_to_phon[tag]],
-                synt=[[]],
+                synt=[],
                 eval=[[]],
             )
         )
@@ -82,14 +82,14 @@ def get_special_lemma_lexicon():
     # create special lemmas
     lex.add_lemma(
         lexicon.Lemma(
-            orth=["[SENTENCE-END]"], synt=[["</s>"]], special="sentence-boundary"
+            orth=["[SENTENCE-END]"], synt=["</s>"], special="sentence-boundary"
         )
     )
 
     lex.add_lemma(
         lexicon.Lemma(
             orth=["[sentence-begin]"],
-            synt=[["<s>"]],
+            synt=["<s>"],
             eval=[[]],
             special="sentence-begin",
         )
@@ -97,7 +97,7 @@ def get_special_lemma_lexicon():
 
     lex.add_lemma(
         lexicon.Lemma(
-            orth=["[sentence-end]"], synt=[["</s>"]], eval=[[]], special="sentence-end"
+            orth=["[sentence-end]"], synt=["</s>"], eval=[[]], special="sentence-end"
         )
     )
 
@@ -105,16 +105,14 @@ def get_special_lemma_lexicon():
         lexicon.Lemma(
             orth=["[SILENCE]", ""],
             phon=["[SILENCE]"],
-            synt=[[]],
+            synt=[],
             eval=[[]],
             special="silence",
         )
     )
 
     lex.add_lemma(
-        lexicon.Lemma(
-            orth=["[UNKNOWN]"], synt=[["<unk>"]], eval=[[]], special="unknown"
-        )
+        lexicon.Lemma(orth=["[UNKNOWN]"], synt=["<unk>"], eval=[[]], special="unknown")
     )
 
     return lex


### PR DESCRIPTION
The RASR Lexicon only supports a single syntactic token sequence per lemma while our implementation in i6_core supports multiple. The PR https://github.com/rwth-i6/i6_core/pull/185 fixes this.

This PR is to adapt the current recipes to the new interface and should land together with the PR in i6_core.