### PR TITLE
adapt to new lexicon parameter types

### DIFF
--- a/common/datasets/librispeech.py
+++ b/common/datasets/librispeech.py
@@ -318,24 +318,22 @@ def get_special_lemma_lexicon():
         lexicon.Lemma(
             orth=["[SILENCE]", ""],
             phon=["[SILENCE]"],
-            synt=[[]],
+            synt=[],
             special="silence",
             eval=[[]],
         )
     )
     lex.add_lemma(
-        lexicon.Lemma(
-            orth=["[SENTENCE-BEGIN]"], synt=[["<s>"]], special="sentence-begin"
-        )
+        lexicon.Lemma(orth=["[SENTENCE-BEGIN]"], synt=["<s>"], special="sentence-begin")
     )
     lex.add_lemma(
-        lexicon.Lemma(orth=["[SENTENCE-END]"], synt=[["</s>"]], special="sentence-end")
+        lexicon.Lemma(orth=["[SENTENCE-END]"], synt=["</s>"], special="sentence-end")
     )
     lex.add_lemma(
         lexicon.Lemma(
             orth=["[UNKNOWN]"],
             phon=["[UNKNOWN]"],
-            synt=[["<UNK>"]],
+            synt=["<UNK>"],
             special="unknown",
         )
     )


### PR DESCRIPTION
There was a fix for the Lexicon: https://github.com/rwth-i6/i6_core/pull/188
I adjusted it to not break hashes, but the parameters need to be adapted to the new and correct format, otherwise there is an assertion error now. I would have pushed this directly, but I wanted to inform you about this change so that you update i6_core and i6_experiments at the same time.

I hope I did not forget anyone who uses the new Librispeech pipeline (or at least the lexicon).