### PR TITLE
Improved CutAndStitchSpeechSegmentsFromCorpusJob to create longer aud…

### DIFF
--- a/users/dierkes/preprocessing/segment_cutting.py
+++ b/users/dierkes/preprocessing/segment_cutting.py
@@ -2,10 +2,13 @@ import soundfile as sf
 import numpy as np
 import multiprocessing
 import logging
+import os
+import matplotlib.pyplot as plt
 
 from sisyphus import Job, Task, tk
 
 from i6_core.lib import corpus
+
 
 class CutAndStitchSpeechSegmentsFromCorpusJob(Job):
     """
@@ -15,27 +18,47 @@ class CutAndStitchSpeechSegmentsFromCorpusJob(Job):
 
 
     """
-    def __init__(self, bliss_corpus_file, target_length=20, n_workers=4, file_extension='wav'):
+
+    def __init__(
+        self,
+        bliss_corpus_file,
+        min_length=10,
+        target_length=20,
+        n_workers=4,
+        file_extension="wav",
+    ):
         """
 
         :param tk.Path bliss_corpus:
+        :param int min_length: minimal length of the stitched extracted speech in seconds. Note that
+            this constraint might be violated in some cases, e.g. when a recording contains less
+            speech than min_length or because the greedy stitching strategy might produce leftover
+            files for every recording shorter than min_length
         :param int target_length: target length of the stitched extracted speech in seconds
         :param int n_workers: number of threads for work on files in parallel
         :param str file_extension: currently supported are wav, flac and mp3
         """
         self.bliss_corpus_file = bliss_corpus_file
+        self.min_length = min_length
         self.target_length = target_length
         self.n_workers = n_workers
         self.file_extension = file_extension
-        assert file_extension in ['wav', 'flac', 'mp3']
+        assert file_extension in ["wav", "flac", "mp3"]
 
         self.out_audio_path = self.output_path("audio/", directory=True)
-        self.rqmt = {'time': 8, 'mem': 16, 'cpu': self.n_workers}
+        self.out_length_hist = self.output_path("file_length_hist.png")
+        self.cut_and_stitch_segments_rqmt = {
+            "time": 8,
+            "mem": 16,
+            "cpu": self.n_workers,
+        }
+        self.length_dist_rqmt = {"time": 2, "mem": 1, "cpu": self.n_workers}
 
     def tasks(self):
-        yield Task("run", rqmt=self.rqmt)
+        yield Task("cut_and_stitch_segments", rqmt=self.cut_and_stitch_segments_rqmt)
+        yield Task("plot_length_distribution", rqmt=self.length_dist_rqmt)
 
-    def run(self):
+    def cut_and_stitch_segments(self):
         self.corpus_object = corpus.Corpus()
         self.corpus_object.load(self.bliss_corpus_file.get_path())
         recordings = list(self.corpus_object.all_recordings())
@@ -43,14 +66,44 @@ class CutAndStitchSpeechSegmentsFromCorpusJob(Job):
         print(f"{len(recordings)} recordings detected")
         print(f"launching {self.n_workers} processes")
 
-        tasks = [(r, self.out_audio_path, self.target_length, self.file_extension) for r in recordings]
+        tasks = [(r, self.out_audio_path.get_path(), self.file_extension) for r in recordings]
         with multiprocessing.Pool(processes=self.n_workers) as pool:
             for i, _ in enumerate(pool.imap_unordered(self.cut_file, tasks)):
                 if i % 100 == 0:
                     logging.info(f"{i} of {len(tasks)} files done")
 
+    def plot_length_distribution(self):
+        files = [
+            f"{self.out_audio_path.get_path()}/{f}"
+            for f in os.listdir(self.out_audio_path.get_path())
+            if os.path.splitext(f)[1] == f".{self.file_extension}"
+        ]
+        num_files = len(files)
+
+        with multiprocessing.Pool(processes=self.n_workers) as pool:
+            file_lengths = list(pool.imap_unordered(self.get_length, files, 100))
+
+        avg_length = round(sum(file_lengths) / num_files, 2)
+        length = round(sum(file_lengths) / 3600, 2)
+        fig, ax = plt.subplots()
+        ax.hist(file_lengths, bins=80)
+        fig.text(
+            0.5,
+            0.9,
+            f"Average length: {avg_length}s, Summed length: {length}h",
+            ha="center",
+            va="center",
+        )
+        ax.set_ylabel("count")
+        ax.set_xlabel("file length")
+        plt.savefig(self.out_length_hist.get_path())
+
+    def get_length(self, file):
+        f = sf.SoundFile(file)
+        return f.frames / f.samplerate
+
     def cut_file(self, task):
-        recording, root_out, target_len_sec, extension = task
+        recording, root_out, extension = task
         recording_path = recording.audio
         recording_name = recording.name
 
@@ -70,16 +123,38 @@ class CutAndStitchSpeechSegmentsFromCorpusJob(Job):
             end_index = int(end * samplerate)
             slice = data[start_index:end_index]
 
-            # if a slice is longer than target_len_sec, we put it entirely in it's own piece
-            if length_accumulated + (end - start) > target_len_sec and length_accumulated > 0:
+            if (end - start) > self.target_length:
                 file_out = f"{root_out}/{recording_name}_{i}.{extension}"
-                sf.write(file_out, np.hstack(to_stitch), samplerate=samplerate)
-                to_stitch = []
+                sf.write(file_out, slice, samplerate=samplerate)
                 i += 1
+            elif (
+                length_accumulated + (end - start) > self.target_length
+                and max(length_accumulated, end - start) >= self.min_length
+            ):
+                if (end - start) > length_accumulated:
+                    file_out = f"{root_out}/{recording_name}_{i}.{extension}"
+                    sf.write(file_out, slice, samplerate=samplerate)
+                    i += 1
+                else:
+                    file_out = f"{root_out}/{recording_name}_{i}.{extension}"
+                    sf.write(file_out, np.hstack(to_stitch), samplerate=samplerate)
+                    to_stitch = [slice]
+                    length_accumulated = end - start
+                    i += 1
+            elif (
+                length_accumulated + (end - start) > self.target_length
+                and max(length_accumulated, end - start) < self.min_length
+            ):
+                file_out = f"{root_out}/{recording_name}_{i}.{extension}"
+                sf.write(
+                    file_out, np.hstack(to_stitch + [slice]), samplerate=samplerate
+                )
+                to_stitch = []
                 length_accumulated = 0
-
-            to_stitch.append(slice)
-            length_accumulated += end - start
+                i += 1
+            else:
+                to_stitch.append(slice)
+                length_accumulated += end - start
 
         if to_stitch:
             file_out = f"{root_out}/{recording_name}_{i}.{extension}"
@@ -89,6 +164,7 @@ class CutAndStitchSpeechSegmentsFromCorpusJob(Job):
     def hash(cls, kwargs):
         d = {
             "bliss_corpus_file": kwargs["bliss_corpus_file"],
+            "min_length": kwargs["min_length"],
             "target_length": kwargs["target_length"],
             "file_extension": kwargs["file_extension"],
         }

--- a/users/dierkes/preprocessing/segment_cutting.py
+++ b/users/dierkes/preprocessing/segment_cutting.py
@@ -19,8 +19,6 @@ class CutAndStitchSpeechSegmentsFromCorpusJob(Job):
 
     """
 
-    __sis_hash_exclude__ = {"min_length": 0}
-
     def __init__(
         self,
         bliss_corpus_file,
@@ -82,13 +80,9 @@ class CutAndStitchSpeechSegmentsFromCorpusJob(Job):
         ]
         num_files = len(files)
 
-        global get_length
-        def get_length(file):
-            f = sf.SoundFile(file)
-            return f.frames / f.samplerate
 
         with multiprocessing.Pool(processes=self.n_workers) as pool:
-            file_lengths = list(pool.imap_unordered(get_length, files, 100))
+            file_lengths = list(pool.imap_unordered(self.get_length, files, 100))
 
         avg_length = round(sum(file_lengths) / num_files, 2)
         length = round(sum(file_lengths) / 3600, 2)
@@ -105,6 +99,10 @@ class CutAndStitchSpeechSegmentsFromCorpusJob(Job):
         ax.set_xlabel("file length [sec]")
         plt.savefig(self.out_length_hist.get_path())
 
+    @staticmethod
+    def get_length(file):
+        f = sf.SoundFile(file)
+        return f.frames / f.samplerate
 
     def cut_file(self, task):
         recording, root_out, extension = task

--- a/users/dierkes/preprocessing/segment_cutting.py
+++ b/users/dierkes/preprocessing/segment_cutting.py
@@ -19,6 +19,8 @@ class CutAndStitchSpeechSegmentsFromCorpusJob(Job):
 
     """
 
+    __sis_hash_exclude__ = {"min_length": 0}
+
     def __init__(
         self,
         bliss_corpus_file,

--- a/users/dierkes/preprocessing/segment_cutting.py
+++ b/users/dierkes/preprocessing/segment_cutting.py
@@ -80,8 +80,13 @@ class CutAndStitchSpeechSegmentsFromCorpusJob(Job):
         ]
         num_files = len(files)
 
+        global get_length
+        def get_length(file):
+            f = sf.SoundFile(file)
+            return f.frames / f.samplerate
+
         with multiprocessing.Pool(processes=self.n_workers) as pool:
-            file_lengths = list(pool.imap_unordered(self.get_length, files, 100))
+            file_lengths = list(pool.imap_unordered(get_length, files, 100))
 
         avg_length = round(sum(file_lengths) / num_files, 2)
         length = round(sum(file_lengths) / 3600, 2)
@@ -95,12 +100,9 @@ class CutAndStitchSpeechSegmentsFromCorpusJob(Job):
             va="center",
         )
         ax.set_ylabel("count")
-        ax.set_xlabel("file length")
+        ax.set_xlabel("file length [sec]")
         plt.savefig(self.out_length_hist.get_path())
 
-    def get_length(self, file):
-        f = sf.SoundFile(file)
-        return f.frames / f.samplerate
 
     def cut_file(self, task):
         recording, root_out, extension = task


### PR DESCRIPTION
…io files and job now gives more control to user to specify resulting file lengths.

Additionally the Job now always creates a histogram of the file lengths so that one can directly investigate the length distribution. A comparison can be seen below. First the old job segmentation, second the new job segmentation for the vietnamese data with target length 20 seconds and minimal length of 10 seconds:
![file_lengths_hist](https://user-images.githubusercontent.com/63733611/160782463-e10a363a-442f-49c2-b4dd-b0e1bb3d8272.png)
![file_length_hist](https://user-images.githubusercontent.com/63733611/160782597-4e0f20b7-5d44-4a88-ba36-83360539b79e.png)

@vieting