### PR TITLE
add action alias and align report output

### DIFF
--- a/common/setups/rasr/gmm_system.py
+++ b/common/setups/rasr/gmm_system.py
@@ -267,7 +267,9 @@ class GmmSystem(RasrSystem):
         if dump_alignment_score_report:
             tk.register_output(
                 "train/{}_{}_alignment_report.txt".format(corpus_key, name),
-                self.jobs[corpus_key]["train_{}".format(name)].get_alignment_score_report()
+                self.jobs[corpus_key][
+                    "train_{}".format(name)
+                ].get_alignment_score_report(),
             )
 
         state_tying_job = allophones.DumpStateTyingJob(self.crp[corpus_key])
@@ -438,8 +440,11 @@ class GmmSystem(RasrSystem):
         if dump_alignment_score_report:
             tk.register_output(
                 "train/{}_{}_alignment_report.txt".format(corpus_key, name),
-                self.jobs[corpus_key]["train_{}".format(name)].get_alignment_score_report()
+                self.jobs[corpus_key][
+                    "train_{}".format(name)
+                ].get_alignment_score_report(),
             )
+
     # -------------------- Vocal Tract Length Normalization --------------------
 
     def vtln_feature_flow(
@@ -636,7 +641,9 @@ class GmmSystem(RasrSystem):
         if dump_alignment_score_report:
             tk.register_output(
                 "train/{}_{}_alignment_report.txt".format(corpus_key, name),
-                self.jobs[corpus_key]["train_{}".format(name)].get_alignment_score_report()
+                self.jobs[corpus_key][
+                    "train_{}".format(name)
+                ].get_alignment_score_report(),
             )
 
     # -------------------- Speaker Adaptive Training  --------------------
@@ -825,7 +832,9 @@ class GmmSystem(RasrSystem):
         if dump_alignment_score_report:
             tk.register_output(
                 "train/{}_{}_alignment_report.txt".format(corpus_key, name),
-                self.jobs[corpus_key]["train_{}".format(name)].get_alignment_score_report()
+                self.jobs[corpus_key][
+                    "train_{}".format(name)
+                ].get_alignment_score_report(),
             )
 
     # -------------------- recognition  --------------------

--- a/common/setups/rasr/gmm_system.py
+++ b/common/setups/rasr/gmm_system.py
@@ -193,6 +193,7 @@ class GmmSystem(RasrSystem):
         splits: int,
         accs_per_split: int,
         align_keep_values: Optional[dict] = None,
+        dump_alignment_score_report=False,
         **kwargs,
     ):
         """
@@ -206,7 +207,10 @@ class GmmSystem(RasrSystem):
         :param splits:
         :param accs_per_split:
         :param align_keep_values:
-        :param kwargs:
+        :param dump_alignment_score_report: collect the alignment logs and write the report.
+            please do not activate this flag if you already cleaned all alignments, as then all deleted
+            jobs will re-run.
+        :param kwargs: passed to AlignSplitAccumulateSequence
         :return:
         """
         if linear_alignment_args is not None:
@@ -238,6 +242,7 @@ class GmmSystem(RasrSystem):
                 self.mixtures, corpus_key, "linear_alignment_{}".format(name)
             ),
             align_keep_values=akv,
+            alias_path="train/{}_{}_action_sequence".format(corpus_key, name),
             **kwargs,
         )
         self.jobs[corpus_key]["train_{}".format(name)].selected_alignment_jobs[
@@ -259,6 +264,11 @@ class GmmSystem(RasrSystem):
             .selected_mixture_jobs[-1]
             .out_mixtures,
         )
+        if dump_alignment_score_report:
+            tk.register_output(
+                "train/{}_{}_alignment_report.txt".format(corpus_key, name),
+                self.jobs[corpus_key]["train_{}".format(name)].get_alignment_score_report()
+            )
 
         state_tying_job = allophones.DumpStateTyingJob(self.crp[corpus_key])
         tk.register_output(
@@ -362,6 +372,7 @@ class GmmSystem(RasrSystem):
         splits: int,
         accs_per_split: int,
         align_keep_values: Optional[dict] = None,
+        dump_alignment_score_report=False,
         **kwargs,
     ):
         """
@@ -374,7 +385,10 @@ class GmmSystem(RasrSystem):
         :param splits:
         :param accs_per_split:
         :param align_keep_values:
-        :param kwargs:
+        :param dump_alignment_score_report: collect the alignment logs and write the report.
+            please do not activate this flag if you already cleaned all alignments, as then all deleted
+            jobs will re-run.
+        :param kwargs: passed to AlignSplitAccumulateSequence
         :return:
         """
 
@@ -399,6 +413,7 @@ class GmmSystem(RasrSystem):
                 self.alignments, corpus_key, initial_alignment
             ),
             align_keep_values=akv,
+            alias_path="train/{}_{}_action_sequence".format(corpus_key, name),
             **kwargs,
         )
         self.jobs[corpus_key]["train_{}".format(name)].selected_alignment_jobs[
@@ -420,7 +435,11 @@ class GmmSystem(RasrSystem):
             .selected_mixture_jobs[-1]
             .out_mixtures,
         )
-
+        if dump_alignment_score_report:
+            tk.register_output(
+                "train/{}_{}_alignment_report.txt".format(corpus_key, name),
+                self.jobs[corpus_key]["train_{}".format(name)].get_alignment_score_report()
+            )
     # -------------------- Vocal Tract Length Normalization --------------------
 
     def vtln_feature_flow(
@@ -556,6 +575,7 @@ class GmmSystem(RasrSystem):
         splits: int,
         accs_per_split: int,
         align_keep_values: Optional[dict] = None,
+        dump_alignment_score_report=False,
         **kwargs,
     ):
         """
@@ -568,7 +588,10 @@ class GmmSystem(RasrSystem):
         :param splits:
         :param accs_per_split:
         :param align_keep_values:
-        :param kwargs:
+        :param dump_alignment_score_report: collect the alignment logs and write the report.
+            please do not activate this flag if you already cleaned all alignments, as then all deleted
+            jobs will re-run.
+        :param kwargs: passed to AlignSplitAccumulateSequence
         :return:
         """
         action_sequence = (
@@ -588,6 +611,7 @@ class GmmSystem(RasrSystem):
             flow=feature_flow,
             initial_alignment=self.alignments[corpus_key][initial_alignment_key][-1],
             align_keep_values=akv,
+            alias_path="train/{}_{}_action_sequence".format(corpus_key, name),
             **kwargs,
         )
         self.jobs[corpus_key]["train_{}".format(name)].selected_alignment_jobs[
@@ -609,6 +633,11 @@ class GmmSystem(RasrSystem):
             .selected_mixture_jobs[-1]
             .out_mixtures,
         )
+        if dump_alignment_score_report:
+            tk.register_output(
+                "train/{}_{}_alignment_report.txt".format(corpus_key, name),
+                self.jobs[corpus_key]["train_{}".format(name)].get_alignment_score_report()
+            )
 
     # -------------------- Speaker Adaptive Training  --------------------
 
@@ -716,6 +745,7 @@ class GmmSystem(RasrSystem):
         splits: int,
         accs_per_split: int,
         align_keep_values: Optional[dict] = None,
+        dump_alignment_score_report=False,
         **kwargs,
     ):
         """
@@ -731,7 +761,10 @@ class GmmSystem(RasrSystem):
         :param splits:
         :param accs_per_split:
         :param align_keep_values:
-        :param kwargs:
+        :param dump_alignment_score_report: collect the alignment logs and write the report.
+            please do not activate this flag if you already cleaned all alignments, as then all deleted
+            jobs will re-run.
+        :param kwargs: passed to AlignSplitAccumulateSequence
         :return:
         """
         self.estimate_cmllr(
@@ -767,6 +800,7 @@ class GmmSystem(RasrSystem):
                 self.alignments, corpus_key, alignment
             ),
             align_keep_values=akv,
+            alias_path="train/{}_{}_action_sequence".format(corpus_key, name),
             **kwargs,
         )
         self.jobs[corpus_key]["train_{}".format(name)].selected_alignment_jobs[
@@ -788,6 +822,11 @@ class GmmSystem(RasrSystem):
             .selected_mixture_jobs[-1]
             .out_mixtures,
         )
+        if dump_alignment_score_report:
+            tk.register_output(
+                "train/{}_{}_alignment_report.txt".format(corpus_key, name),
+                self.jobs[corpus_key]["train_{}".format(name)].get_alignment_score_report()
+            )
 
     # -------------------- recognition  --------------------
 


### PR DESCRIPTION
This now creates the alias folders for the action sequence as discussed, and writes the alignment log scores to a file if enabled.