### PR TITLE
add manual blas lib option for hybrid

### DIFF
--- a/common/setups/rasr/hybrid_system.py
+++ b/common/setups/rasr/hybrid_system.py
@@ -70,11 +70,13 @@ class HybridSystem(NnSystem):
         returnn_root: Optional[str] = None,
         returnn_python_home: Optional[str] = None,
         returnn_python_exe: Optional[str] = None,
+        blas_lib: Optional[str] = None,
     ):
         super().__init__(
             returnn_root=returnn_root,
             returnn_python_home=returnn_python_home,
             returnn_python_exe=returnn_python_exe,
+            blas_lib=blas_lib,
         )
 
         self.tf_fwd_input_name = "tf-fwd-input"
@@ -481,7 +483,9 @@ class HybridSystem(NnSystem):
                 "NativeLstm2",
                 returnn_root=self.returnn_root,
                 returnn_python_exe=self.returnn_python_exe,
+                blas_lib=self.blas_lib,
             )
+            native_lstm_job.add_alias("%s/compile_native_op" % name)
 
             graph_compile_job = returnn.CompileTFGraphJob(
                 self.adapt_returnn_config_for_recog(returnn_config),

--- a/common/setups/rasr/nn_system.py
+++ b/common/setups/rasr/nn_system.py
@@ -49,6 +49,7 @@ class NnSystem(RasrSystem):
         returnn_root: Optional[str] = None,
         returnn_python_home: Optional[str] = None,
         returnn_python_exe: Optional[str] = None,
+        blas_lib: Optional[str] = None,
     ):
         super().__init__()
 
@@ -61,3 +62,5 @@ class NnSystem(RasrSystem):
         self.returnn_python_exe = returnn_python_exe or (
             gs.RETURNN_PYTHON_EXE if hasattr(gs, "RETURNN_PYTHON_EXE") else None
         )
+
+        self.blas_lib = blas_lib or (gs.BLAS_LIB if hasattr(gs, "BLAS_LIB") else None)


### PR DESCRIPTION
Adds an option to the `nn_system` and `hybrid_system` respectively to set a specific blas (or MKL) library for compiling the native op.

This is only needed for models with native-LSTM, but allows significant speedups in some cases.

