### PR TITLE
important fixes for hybrid recognition

### DIFF
--- a/common/setups/rasr/util/nn.py
+++ b/common/setups/rasr/util/nn.py
@@ -201,14 +201,18 @@ class OggZipHdfDataInput:
 class HybridArgs:
     def __init__(
         self,
-        returnn_configs: Dict[str, returnn.ReturnnConfig],
+        returnn_training_configs: Dict[str, returnn.ReturnnConfig],
+        returnn_recognition_configs: Dict[str, returnn.ReturnnConfig],
         training_args: Dict[str, Any],
         recognition_args: Dict[str, Dict[str, Dict]],
         test_recognition_args: Optional[Dict[str, Dict[str, Dict]]] = None,
     ):
         """
         ##################################################
-        :param returnn_configs
+        :param returnn_training_configs
+        ##################################################
+        :param returnn_recognition_configs
+            If a config is not found here, the corresponding training config is used
         ##################################################
         :param training_args:
         ##################################################
@@ -217,7 +221,8 @@ class HybridArgs:
         :param test_recognition_args:
         ##################################################
         """
-        self.returnn_configs = returnn_configs
+        self.returnn_training_configs = returnn_training_configs
+        self.returnn_recognition_configs = returnn_recognition_configs
         self.training_args = training_args
         self.recognition_args = recognition_args
         self.test_recognition_args = test_recognition_args

--- a/users/rossenbach/experiments/librispeech/librispeech_100_gmm/baseline_args_common.py
+++ b/users/rossenbach/experiments/librispeech/librispeech_100_gmm/baseline_args_common.py
@@ -127,7 +127,7 @@ def get_monophone_args():
         'lm_scales': [10],
         'optimize_am_lm_scale': True,
         # meta.System.recog() args:
-        'feature_flow': 'mfcc+deriv', # +norm
+        'feature_flow': 'mfcc+deriv+norm',
         'pronunciation_scales': [1.0],
         'lm_lookahead': True,
         'lookahead_options': None,


### PR DESCRIPTION
Allows for separate training and recognition Returnn configs, and uses `log_output` as default layer, which should be defined correctly in the Returnn config in order to be able to ignore #40.