### PR TITLE
feat: Improve typings in RASR-specific i6_experiments code

### DIFF
--- a/common/setups/rasr/util/rasr.py
+++ b/common/setups/rasr/util/rasr.py
@@ -5,9 +5,9 @@ __all__ = [
     "RasrSteps",
 ]
 
-
 from collections import OrderedDict
-from typing import Dict, Optional, Union
+from dataclasses import asdict, dataclass
+from typing import Dict, Optional, Union, Tuple, List
 
 import i6_core.meta as meta
 
@@ -48,6 +48,21 @@ class CostaArgs(dict):
         self.eval_lm = eval_lm
 
 
+@dataclass
+class AmArgs:
+    state_tying: str
+    states_per_phone: int
+    state_repetitions: int
+    across_word_model: bool
+    early_recombination: bool
+    tdp_scale: float
+    tdp_transition: Tuple[Union[float, str], Union[float, str], Union[float, str], Union[float, str]]
+    tdp_silence: Tuple[Union[float, str], Union[float, str], Union[float, str], Union[float, str]]
+    tying_type: str
+    nonword_phones: Union[str, List[str]]
+    tdp_nonword: Tuple[Union[float, str], Union[float, str], Union[float, str], Union[float, str]]
+
+
 class RasrInitArgs:
     """
     Class holds general information for the complete pipeline.
@@ -62,7 +77,7 @@ class RasrInitArgs:
     def __init__(
         self,
         costa_args: Union[dict, CostaArgs],
-        am_args: dict,
+        am_args: Union[dict, AmArgs],
         feature_extraction_args: dict,
         scorer: Optional[str] = None,
         scorer_args: Optional[Dict] = None,
@@ -168,7 +183,7 @@ class RasrInitArgs:
         self.costa_args = costa_args
         self.scorer = scorer
         self.scorer_args = scorer_args
-        self.am_args = am_args
+        self.am_args = am_args if not isinstance(am_args, AmArgs) else asdict(am_args)
         self.feature_extraction_args = feature_extraction_args
         self.stm_args = stm_args
 

--- a/common/setups/rasr/util/rasr.py
+++ b/common/setups/rasr/util/rasr.py
@@ -7,7 +7,7 @@ __all__ = [
 
 
 from collections import OrderedDict
-from typing import Dict, Optional
+from typing import Dict, Optional, Union
 
 import i6_core.meta as meta
 
@@ -40,6 +40,14 @@ class RasrDataInput:
         self.concurrent = concurrent
 
 
+class CostaArgs(dict):
+    def __init__(self, eval_recordings: bool, eval_lm: bool):
+        super(CostaArgs, self).__init__(eval_recordings=eval_recordings, eval_lm=eval_lm)
+
+        self.eval_recordings = eval_recordings
+        self.eval_lm = eval_lm
+
+
 class RasrInitArgs:
     """
     Class holds general information for the complete pipeline.
@@ -53,7 +61,7 @@ class RasrInitArgs:
 
     def __init__(
         self,
-        costa_args: dict,
+        costa_args: Union[dict, CostaArgs],
         am_args: dict,
         feature_extraction_args: dict,
         scorer: Optional[str] = None,


### PR DESCRIPTION
Hi!

In an effort to improve documentation of the RASR specific code in i6_experiments, I plan on improving the typings and to reduce the usage of `dict`s for storing configuration options. The idea is to create classes for all the options being passed to RASR that are then composed in a type-correct way. This on one hand documents the available config knobs in RASR, and on another hand makes it easier for newcomers to know which parameters are allowed in which positions.

The existing parameter creation code (e.g. in `users/luescher/setups/librispeech/pipeline_base_args.py`) and the code in the `{Gmm, Hybrid}System` classes, however, heavily relies on either producing or receiving plain python dicts. Both code bases use `.keys()`, `.items()`, etc.

This poses a problem, given that plain data classes lack these functions. I see three options:

1. Create the classes and change all the code to use them instead of dicts
2. Create the classes, but make them behave like dicts by inheriting from the `dict` class, so that the existing code continues to work
3. Create the classes and convert them to dicts before they are being passed downstream

Option 1 seems like a lot of work. Option 2 seems like the most incremental solution given that all existing code continues to work, but might be a) verbose and b) fragile. The verbosity can possibly be reduced by using a custom decorator that works similarly to `@dataclass` (or even uses that under the hood), but this again has a learning overhead. Option 3 possibly leads to the cleanest code during typing, but then loses the type information again during the conversion back to a dict.

This PR is meant to kick off the discussion on which approach is best. I've implemented option 2 and 3 for one parameter each. I have already spoken to @christophmluscher about this, and we would like to get your feedback @JackTemaki.

cc @christophmluscher @JackTemaki for reviews