### PR TITLE
cut and stitch job: modify parallelization

### DIFF
--- a/users/dierkes/preprocessing/segment_cutting.py
+++ b/users/dierkes/preprocessing/segment_cutting.py
@@ -54,7 +54,11 @@ class CutAndStitchSpeechSegmentsFromCorpusJob(Job):
         self.length_dist_rqmt = None  # noqa, for backwards compatibility
 
     def tasks(self):
-        yield Task("cut_and_stitch_segments", rqmt=self.cut_and_stitch_segments_rqmt, args=range(1, self.n_workers + 1))
+        yield Task(
+            "cut_and_stitch_segments",
+            rqmt=self.cut_and_stitch_segments_rqmt,
+            args=range(1, self.n_workers + 1),
+        )
         yield Task("plot_length_distribution", mini_task=True)
 
     def cut_and_stitch_segments(self, task_id):
@@ -62,7 +66,7 @@ class CutAndStitchSpeechSegmentsFromCorpusJob(Job):
         corpus_object.load(self.bliss_corpus_file.get_path())
         recordings = list(corpus_object.all_recordings())
         print(f"{len(recordings)} recordings detected")
-        recordings = recordings[task_id - 1::self.n_workers]
+        recordings = recordings[task_id - 1 :: self.n_workers]
         print(f"processing {len(recordings)} of them")
 
         file_lengths = []
@@ -70,7 +74,9 @@ class CutAndStitchSpeechSegmentsFromCorpusJob(Job):
             self.cut_file(rec, self.out_audio_path.get_path(), self.file_extension)
             for file_name in os.listdir(self.out_audio_path.get_path()):
                 if file_name.startswith(rec.name):
-                    file_length = self.get_length(os.path.join(self.out_audio_path.get_path(), file_name))
+                    file_length = self.get_length(
+                        os.path.join(self.out_audio_path.get_path(), file_name)
+                    )
                     file_lengths.append(str(file_length))
             if rec_idx % 100 == 0:
                 logging.info(f"{rec_idx} of {len(recordings)} files done")
@@ -82,7 +88,9 @@ class CutAndStitchSpeechSegmentsFromCorpusJob(Job):
         for file_name in os.listdir():
             if file_name.startswith("file_lengths."):
                 with open(file_name, "r") as f:
-                    file_lengths += [float(file_length.strip()) for file_length in f.readlines()]
+                    file_lengths += [
+                        float(file_length.strip()) for file_length in f.readlines()
+                    ]
 
         avg_length = round(sum(file_lengths) / len(file_lengths), 2)
         length = round(sum(file_lengths) / 3600, 2)

--- a/users/dierkes/preprocessing/segment_cutting.py
+++ b/users/dierkes/preprocessing/segment_cutting.py
@@ -49,7 +49,7 @@ class CutAndStitchSpeechSegmentsFromCorpusJob(Job):
         self.cut_and_stitch_segments_rqmt = {
             "time": 8,
             "mem": 16,
-            "cpu": self.n_workers,
+            "cpu": 1,
         }
         self.length_dist_rqmt = None  # noqa, for backwards compatibility
 

--- a/users/dierkes/preprocessing/segment_cutting.py
+++ b/users/dierkes/preprocessing/segment_cutting.py
@@ -1,6 +1,5 @@
 import soundfile as sf
 import numpy as np
-import multiprocessing
 import logging
 import os
 import matplotlib.pyplot as plt
@@ -52,11 +51,11 @@ class CutAndStitchSpeechSegmentsFromCorpusJob(Job):
             "mem": 16,
             "cpu": self.n_workers,
         }
-        self.length_dist_rqmt = {"time": 2, "mem": 1, "cpu": self.n_workers}
+        self.length_dist_rqmt = None  # noqa, for backwards compatibility
 
     def tasks(self):
         yield Task("cut_and_stitch_segments", rqmt=self.cut_and_stitch_segments_rqmt, args=range(1, self.n_workers + 1))
-        yield Task("plot_length_distribution", rqmt=self.length_dist_rqmt)
+        yield Task("plot_length_distribution", mini_task=True)
 
     def cut_and_stitch_segments(self, task_id):
         corpus_object = corpus.Corpus()
@@ -66,24 +65,26 @@ class CutAndStitchSpeechSegmentsFromCorpusJob(Job):
         recordings = recordings[task_id - 1::self.n_workers]
         print(f"processing {len(recordings)} of them")
 
+        file_lengths = []
         for rec_idx, rec in enumerate(recordings):
             self.cut_file(rec, self.out_audio_path.get_path(), self.file_extension)
+            for file_name in os.listdir(self.out_audio_path.get_path()):
+                if file_name.startswith(rec.name):
+                    file_length = self.get_length(os.path.join(self.out_audio_path.get_path(), file_name))
+                    file_lengths.append(str(file_length))
             if rec_idx % 100 == 0:
                 logging.info(f"{rec_idx} of {len(recordings)} files done")
+        with open(f"file_lengths.{task_id}", "w") as f:
+            f.write("\n".join(file_lengths))
 
     def plot_length_distribution(self):
-        files = [
-            f"{self.out_audio_path.get_path()}/{f}"
-            for f in os.listdir(self.out_audio_path.get_path())
-            if os.path.splitext(f)[1] == f".{self.file_extension}"
-        ]
-        num_files = len(files)
+        file_lengths = []
+        for file_name in os.listdir():
+            if file_name.startswith("file_lengths."):
+                with open(file_name, "r") as f:
+                    file_lengths += [float(file_length.strip()) for file_length in f.readlines()]
 
-
-        with multiprocessing.Pool(processes=self.n_workers) as pool:
-            file_lengths = list(pool.imap_unordered(self.get_length, files, 100))
-
-        avg_length = round(sum(file_lengths) / num_files, 2)
+        avg_length = round(sum(file_lengths) / len(file_lengths), 2)
         length = round(sum(file_lengths) / 3600, 2)
         fig, ax = plt.subplots()
         ax.hist(file_lengths, bins=80)


### PR DESCRIPTION
The `CutAndStitchSpeechSegmentsFromCorpusJob` currently does parallelization via `multiprocessing.Pool`. This is limited by the number of workers available on a single node. This PR modifies the job to parallelize via splitting the list of recordings and processing a subset of the recordings in each job split. This is also more in line with how we parallelize in other jobs.

Adding @dierkes-j for visibility since you wrote the job in the first place, but I cannot add you as a reviewer. Please feel free to comment.