### PR TITLE
feat: Add typings based on Typed Dicts for the hybrid pipeline

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.8
     - run: pip install black==22.3.0
     - run: black --diff common/
     - run: black --check common/

--- a/.github/workflows/hashes.yml
+++ b/.github/workflows/hashes.yml
@@ -23,7 +23,7 @@ jobs:
         path: "sisyphus"
     - uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: 3.8
         cache: "pip"
     - run: |
         pip install --user --upgrade pip setuptools wheel

--- a/common/setups/rasr/util/nn.py
+++ b/common/setups/rasr/util/nn.py
@@ -248,7 +248,7 @@ class NnRecogArgs(TypedDict):
     use_gpu: Optional[bool]
 
 
-KeyedRecogArgs = Dict[str, Union[Dict[str, Any], NnRecogArgs]]
+KeyedRecogArgsType = Dict[str, Union[Dict[str, Any], NnRecogArgs]]
 
 
 class EpochPartitioning(TypedDict):
@@ -282,7 +282,7 @@ class HybridArgs:
         returnn_training_configs: Dict[str, returnn.ReturnnConfig],
         returnn_recognition_configs: Dict[str, returnn.ReturnnConfig],
         training_args: Union[Dict[str, Any], NnTrainingArgs],
-        recognition_args: KeyedRecogArgs,
+        recognition_args: KeyedRecogArgsType,
         test_recognition_args: Optional[KeyedRecogArgs] = None,
     ):
         """

--- a/common/setups/rasr/util/nn.py
+++ b/common/setups/rasr/util/nn.py
@@ -2,7 +2,6 @@ __all__ = ["ReturnnRasrDataInput", "OggZipHdfDataInput", "HybridArgs", "NnRecogA
 
 from typing import Any, Dict, List, Optional, Type, Union, TypedDict
 
-from i6_core.rasr import RasrConfig
 from sisyphus import tk
 
 import i6_core.am as am
@@ -260,8 +259,8 @@ class NnTrainingArgs(TypedDict):
     cpu_rqmt: Optional[int]
     device: Optional[str]
     disregarded_classes: Optional[Any]
-    extra_rasr_config: Optional[RasrConfig]
-    extra_rasr_post_config: Optional[RasrConfig]
+    extra_rasr_config: Optional[rasr.RasrConfig]
+    extra_rasr_post_config: Optional[rasr.RasrConfig]
     horovod_num_processes: Optional[int]
     keep_epochs: Optional[bool]
     log_verbosity: Optional[int]

--- a/common/setups/rasr/util/nn.py
+++ b/common/setups/rasr/util/nn.py
@@ -248,6 +248,9 @@ class NnRecogArgs(TypedDict):
     use_gpu: Optional[bool]
 
 
+KeyedRecogArgs = Dict[str, Union[Dict[str, Any], NnRecogArgs]]
+
+
 class EpochPartitioning(TypedDict):
     dev: int
     train: int
@@ -278,9 +281,9 @@ class HybridArgs:
         self,
         returnn_training_configs: Dict[str, returnn.ReturnnConfig],
         returnn_recognition_configs: Dict[str, returnn.ReturnnConfig],
-        training_args: NnTrainingArgs,
-        recognition_args: Dict[str, NnRecogArgs],
-        test_recognition_args: Optional[Dict[str, NnRecogArgs]] = None,
+        training_args: Union[Dict[str, Any], NnTrainingArgs],
+        recognition_args: KeyedRecogArgs,
+        test_recognition_args: Optional[KeyedRecogArgs] = None,
     ):
         """
         ##################################################

--- a/common/setups/rasr/util/nn.py
+++ b/common/setups/rasr/util/nn.py
@@ -278,7 +278,7 @@ class HybridArgs:
         self,
         returnn_training_configs: Dict[str, returnn.ReturnnConfig],
         returnn_recognition_configs: Dict[str, returnn.ReturnnConfig],
-        training_args: Dict[str, NnTrainingArgs],
+        training_args: NnTrainingArgs,
         recognition_args: Dict[str, NnRecogArgs],
         test_recognition_args: Optional[Dict[str, NnRecogArgs]] = None,
     ):

--- a/common/setups/rasr/util/nn.py
+++ b/common/setups/rasr/util/nn.py
@@ -1,18 +1,15 @@
 __all__ = ["ReturnnRasrDataInput", "OggZipHdfDataInput", "HybridArgs", "NnRecogArgs"]
 
-from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any, Dict, List, Optional, Type, Union, TypedDict
 
+from i6_core.rasr import RasrConfig
 from sisyphus import tk
 
 import i6_core.am as am
-import i6_core.meta as meta
 import i6_core.rasr as rasr
 import i6_core.returnn as returnn
 
 from i6_core.util import MultiPath
-
-from .rasr import RasrDataInput
 
 
 class ReturnnRasrDataInput:
@@ -198,18 +195,98 @@ class OggZipHdfDataInput:
         }
 
 
+# Attribute names are invalid identifiers, therefore use old syntax
+SearchParameters = TypedDict(
+    "SearchParameters",
+    {
+        "beam-pruning": float,
+        "beam-pruning-limit": float,
+        "lm-state-pruning": Optional[float],
+        "word-end-pruning": float,
+        "word-end-pruning-limit": float,
+    },
+)
+
+
+class LookaheadOptions(TypedDict):
+    cache_high: Optional[int]
+    cache_low: Optional[int]
+    history_limit: Optional[int]
+    laziness: Optional[int]
+    minimum_representation: Optional[int]
+    tree_cutoff: Optional[int]
+
+
+class LatticeToCtmArgs(TypedDict):
+    best_path_algo: Optional[str]
+    encoding: Optional[str]
+    extra_config: Optional[Any]
+    extra_post_config: Optional[Any]
+    fill_empty_segments: Optional[bool]
+
+
+class NnRecogArgs(TypedDict):
+    acoustic_mixture_path: Optional[tk.Path]
+    checkpoints: Optional[Dict[int, returnn.Checkpoint]]
+    create_lattice: Optional[bool]
+    epochs: Optional[List[int]]
+    eval_best_in_lattice: Optional[bool]
+    eval_single_best: Optional[bool]
+    feature_flow_key: str
+    lattice_to_ctm_kwargs: Optional[LatticeToCtmArgs]
+    lm_lookahead: bool
+    lm_scales: List[float]
+    lookahead_options: Optional[LookaheadOptions]
+    mem: int
+    name: str
+    optimize_am_lm_scale: bool
+    parallelize_conversion: Optional[bool]
+    prior_scales: List[float]
+    pronunciation_scales: List[float]
+    returnn_config: Optional[returnn.ReturnnConfig]
+    rtf: int
+    search_parameters: Optional[SearchParameters]
+    use_gpu: Optional[bool]
+
+
+class EpochPartitioning(TypedDict):
+    dev: int
+    train: int
+
+
+class NnTrainingArgs(TypedDict):
+    buffer_size: Optional[int]
+    class_label_file: Optional[tk.Path]
+    cpu_rqmt: Optional[int]
+    device: Optional[str]
+    disregarded_classes: Optional[Any]
+    extra_rasr_config: Optional[RasrConfig]
+    extra_rasr_post_config: Optional[RasrConfig]
+    horovod_num_processes: Optional[int]
+    keep_epochs: Optional[bool]
+    log_verbosity: Optional[int]
+    mem_rqmt: Optional[int]
+    num_classes: int
+    num_epochs: int
+    partition_epochs: Optional[EpochPartitioning]
+    save_interval: Optional[int]
+    time_rqmt: Optional[int]
+    use_python_control: Optional[bool]
+
+
 class HybridArgs:
     def __init__(
         self,
         returnn_training_configs: Dict[str, returnn.ReturnnConfig],
         returnn_recognition_configs: Dict[str, returnn.ReturnnConfig],
-        training_args: Dict[str, Any],
-        recognition_args: Dict[str, Dict[str, Dict]],
-        test_recognition_args: Optional[Dict[str, Dict[str, Dict]]] = None,
+        training_args: Dict[str, NnTrainingArgs],
+        recognition_args: Dict[str, NnRecogArgs],
+        test_recognition_args: Optional[Dict[str, NnRecogArgs]] = None,
     ):
         """
         ##################################################
         :param returnn_training_configs
+            RETURNN config keyed by training corpus.
         ##################################################
         :param returnn_recognition_configs
             If a config is not found here, the corresponding training config is used
@@ -217,8 +294,10 @@ class HybridArgs:
         :param training_args:
         ##################################################
         :param recognition_args:
+            Configuration for recognition on dev corpora.
         ##################################################
         :param test_recognition_args:
+            Additional configuration for recognition on test corpora. Merged with recognition_args.
         ##################################################
         """
         self.returnn_training_configs = returnn_training_configs
@@ -226,24 +305,3 @@ class HybridArgs:
         self.training_args = training_args
         self.recognition_args = recognition_args
         self.test_recognition_args = test_recognition_args
-
-
-@dataclass()
-class NnRecogArgs:
-    name: str
-    returnn_config: returnn.ReturnnConfig
-    checkpoints: Dict[int, returnn.Checkpoint]
-    acoustic_mixture_path: tk.Path
-    prior_scales: List[float]
-    pronunciation_scales: List[float]
-    lm_scales: List[float]
-    optimize_am_lm_scale: bool
-    feature_flow_key: str
-    search_parameters: Dict
-    lm_lookahead: bool
-    lattice_to_ctm_kwargs: Dict
-    parallelize_conversion: bool
-    rtf: int
-    mem: int
-    lookahead_options: Optional[Dict] = None
-    epochs: Optional[List[int]] = None

--- a/common/setups/rasr/util/nn.py
+++ b/common/setups/rasr/util/nn.py
@@ -283,7 +283,7 @@ class HybridArgs:
         returnn_recognition_configs: Dict[str, returnn.ReturnnConfig],
         training_args: Union[Dict[str, Any], NnTrainingArgs],
         recognition_args: KeyedRecogArgsType,
-        test_recognition_args: Optional[KeyedRecogArgs] = None,
+        test_recognition_args: Optional[KeyedRecogArgsType] = None,
     ):
         """
         ##################################################


### PR DESCRIPTION
This PR improves the documentation for the hybrid pipeline by introducing types for a subset of the parameters. To avoid heavy code changes I used Typed Dicts. The declared classes continue working like plain old regular dicts and inherit all their methods. This is important because the code in the `HybridSystem` makes use of 1) dict-specific methods like `.get()` and 2) uses `**` to forward kwargs, which doesn't work with non-dicts.

cc @christophmluscher @JackTemaki 