### PR TITLE
extend OggZipHdfDataInput

### DIFF
--- a/common/setups/rasr/util/nn.py
+++ b/common/setups/rasr/util/nn.py
@@ -148,13 +148,15 @@ class ReturnnRasrDataInput:
 class OggZipHdfDataInput:
     def __init__(
         self,
-        oggzip_files: tk.Path,
+        oggzip_files: List[tk.Path],
         alignments: tk.Path,
         context_window: Dict,
         audio: Dict,
-        targets: str,
+        targets: Optional[str] = None,
         partition_epoch: int = 1,
         seq_ordering: str = "laplace:.1000",
+        ogg_args: Optional[Dict[str, Any]] = None,
+        acoustic_mixtures: Optional[Union[tk.Path, str]] = None,
     ):
         """
         :param oggzip_files:
@@ -172,6 +174,8 @@ class OggZipHdfDataInput:
         self.partition_epoch = partition_epoch
         self.seq_ordering = seq_ordering
         self.targets = targets
+        self.ogg_args = ogg_args
+        self.acoustic_mixtures = acoustic_mixtures
 
     def get_data_dict(self):
         return {
@@ -188,10 +192,13 @@ class OggZipHdfDataInput:
                     "class": "OggZipDataset",
                     "audio": self.audio,
                     "partition_epoch": self.partition_epoch,
-                    "path": tuple(self.oggzip_files.get_path()),
+                    "path": [
+                        oggzip_file.get_path() for oggzip_file in self.oggzip_files
+                    ],
                     "seq_ordering": self.seq_ordering,
                     "targets": self.targets,
                     "use_cache_manager": True,
+                    **(self.ogg_args or {}),
                 },
             },
             "seq_order_control_dataset": "ogg",

--- a/common/setups/rasr/util/nn.py
+++ b/common/setups/rasr/util/nn.py
@@ -156,7 +156,7 @@ class OggZipHdfDataInput:
         partition_epoch: int = 1,
         seq_ordering: str = "laplace:.1000",
         ogg_args: Optional[Dict[str, Any]] = None,
-        acoustic_mixtures: Optional[Union[tk.Path, str]] = None,
+        acoustic_mixtures: Optional[tk.Path] = None,
     ):
         """
         :param oggzip_files:
@@ -192,9 +192,7 @@ class OggZipHdfDataInput:
                     "class": "OggZipDataset",
                     "audio": self.audio,
                     "partition_epoch": self.partition_epoch,
-                    "path": [
-                        oggzip_file.get_path() for oggzip_file in self.oggzip_files
-                    ],
+                    "path": self.oggzip_files,
                     "seq_ordering": self.seq_ordering,
                     "targets": self.targets,
                     "use_cache_manager": True,


### PR DESCRIPTION
This PR extends the `OggZipHdfDataInput` in some ways:
- `oggzip_files` is now a list of files as its plural formulation already suggested. It is also passed to RETURNN as a list instead of a tuple which is consistent with the docstring there. Note that this changes the hashes, but I think no one is using it so far, at least according to @christophmluscher.
- Make `targets` optional as I think in many cases it would not be used.
- Allow setting more options for the `OggZipDataset` using `ogg_args`. We might also add `hdf_args` if needed at some point.
- Add `acoustic_mixtures`. This is required by the recognition in the `HybridSystem`. I'm not 100% sure whether it's the best solution to add this to the `OggZipHdfDataInput`, but at least it would be consistent with the way it is done for the `ReturnnRasrDataInput`.