### PR TITLE
Keep_value defaults for Split and Accum

### DIFF
--- a/common/setups/rasr/gmm_system.py
+++ b/common/setups/rasr/gmm_system.py
@@ -405,6 +405,8 @@ class GmmSystem(RasrSystem):
         splits: int,
         accs_per_split: int,
         align_keep_values: Optional[dict] = None,
+        split_keep_values: Optional[dict] = None,
+        accum_keep_values: Optional[dict] = None,
         dump_alignment_score_report=False,
         **kwargs,
     ):
@@ -418,6 +420,8 @@ class GmmSystem(RasrSystem):
         :param splits:
         :param accs_per_split:
         :param align_keep_values:
+        :param split_keep_values:
+        :param accum_keep_values:
         :param dump_alignment_score_report: collect the alignment logs and write the report.
             please do not activate this flag if you already cleaned all alignments, as then all deleted
             jobs will re-run.
@@ -437,6 +441,14 @@ class GmmSystem(RasrSystem):
         if align_keep_values is not None:
             akv.update(align_keep_values)
 
+        skv = dict(**self.default_split_keep_values)
+        if split_keep_values is not None:
+            skv.update(split_keep_values)
+
+        ackv = dict(**self.default_accumulate_keep_values)
+        if accum_keep_values is not None:
+            ackv.update(accum_keep_values)
+
         self.train(
             name=name,
             corpus=corpus_key,
@@ -446,6 +458,8 @@ class GmmSystem(RasrSystem):
                 self.alignments, corpus_key, initial_alignment
             ),
             align_keep_values=akv,
+            split_keep_values=skv,
+            accumulate_keep_values=ackv,
             alias_path="train/{}_{}_action_sequence".format(corpus_key, name),
             **kwargs,
         )
@@ -611,6 +625,8 @@ class GmmSystem(RasrSystem):
         splits: int,
         accs_per_split: int,
         align_keep_values: Optional[dict] = None,
+        split_keep_values: Optional[dict] = None,
+        accum_keep_values: Optional[dict] = None,
         dump_alignment_score_report=False,
         **kwargs,
     ):
@@ -624,6 +640,8 @@ class GmmSystem(RasrSystem):
         :param splits:
         :param accs_per_split:
         :param align_keep_values:
+        :param split_keep_values:
+        :param accum_keep_values:
         :param dump_alignment_score_report: collect the alignment logs and write the report.
             please do not activate this flag if you already cleaned all alignments, as then all deleted
             jobs will re-run.
@@ -640,6 +658,14 @@ class GmmSystem(RasrSystem):
         if align_keep_values is not None:
             akv.update(align_keep_values)
 
+        skv = dict(**self.default_split_keep_values)
+        if split_keep_values is not None:
+            skv.update(split_keep_values)
+
+        ackv = dict(**self.default_accumulate_keep_values)
+        if accum_keep_values is not None:
+            ackv.update(accum_keep_values)
+
         self.train(
             name=name,
             corpus=corpus_key,
@@ -647,6 +673,8 @@ class GmmSystem(RasrSystem):
             flow=feature_flow,
             initial_alignment=self.alignments[corpus_key][initial_alignment_key][-1],
             align_keep_values=akv,
+            split_keep_values=skv,
+            accumulate_keep_values=ackv,
             alias_path="train/{}_{}_action_sequence".format(corpus_key, name),
             **kwargs,
         )
@@ -783,6 +811,8 @@ class GmmSystem(RasrSystem):
         splits: int,
         accs_per_split: int,
         align_keep_values: Optional[dict] = None,
+        split_keep_values: Optional[dict] = None,
+        accum_keep_values: Optional[dict] = None,
         dump_alignment_score_report=False,
         **kwargs,
     ):
@@ -799,6 +829,8 @@ class GmmSystem(RasrSystem):
         :param splits:
         :param accs_per_split:
         :param align_keep_values:
+        :param split_keep_values:
+        :param accum_keep_values:
         :param dump_alignment_score_report: collect the alignment logs and write the report.
             please do not activate this flag if you already cleaned all alignments, as then all deleted
             jobs will re-run.
@@ -829,6 +861,14 @@ class GmmSystem(RasrSystem):
         if align_keep_values is not None:
             akv.update(align_keep_values)
 
+        skv = dict(**self.default_split_keep_values)
+        if split_keep_values is not None:
+            skv.update(split_keep_values)
+
+        ackv = dict(**self.default_accumulate_keep_values)
+        if accum_keep_values is not None:
+            ackv.update(accum_keep_values)
+
         self.train(
             name=name,
             corpus=corpus_key,
@@ -838,6 +878,8 @@ class GmmSystem(RasrSystem):
                 self.alignments, corpus_key, alignment
             ),
             align_keep_values=akv,
+            split_keep_values=skv,
+            accumulate_keep_values=ackv,
             alias_path="train/{}_{}_action_sequence".format(corpus_key, name),
             **kwargs,
         )

--- a/common/setups/rasr/gmm_system.py
+++ b/common/setups/rasr/gmm_system.py
@@ -120,6 +120,14 @@ class GmmSystem(RasrSystem):
             "default": 5,
             "selected": gs.JOB_DEFAULT_KEEP_VALUE,
         }
+        self.default_split_keep_values = {
+            "default": 5,
+            "selected": gs.JOB_DEFAULT_KEEP_VALUE,
+        }
+        self.default_accumulate_keep_values = {
+            "default": 5,
+            "selected": gs.JOB_DEFAULT_KEEP_VALUE,
+        }
 
         self.outputs = defaultdict(dict)  # type: Dict[GmmOutput]
 
@@ -202,6 +210,8 @@ class GmmSystem(RasrSystem):
         splits: int,
         accs_per_split: int,
         align_keep_values: Optional[dict] = None,
+        split_keep_values: Optional[dict] = None,
+        accum_keep_values: Optional[dict] = None,
         dump_alignment_score_report=False,
         **kwargs,
     ):
@@ -216,6 +226,8 @@ class GmmSystem(RasrSystem):
         :param splits:
         :param accs_per_split:
         :param align_keep_values:
+        :param split_keep_values:
+        :param accum_keep_values:
         :param dump_alignment_score_report: collect the alignment logs and write the report.
             please do not activate this flag if you already cleaned all alignments, as then all deleted
             jobs will re-run.
@@ -242,6 +254,14 @@ class GmmSystem(RasrSystem):
         if align_keep_values is not None:
             akv.update(align_keep_values)
 
+        skv = dict(**self.default_split_keep_values)
+        if split_keep_values is not None:
+            skv.update(split_keep_values)
+
+        ackv = dict(**self.default_accumulate_keep_values)
+        if accum_keep_values is not None:
+            ackv.update(accum_keep_values)
+
         self.train(
             name=name,
             corpus=corpus_key,
@@ -251,6 +271,8 @@ class GmmSystem(RasrSystem):
                 self.mixtures, corpus_key, "linear_alignment_{}".format(name)
             ),
             align_keep_values=akv,
+            split_keep_values=skv,
+            accumulate_keep_values=ackv,
             alias_path="train/{}_{}_action_sequence".format(corpus_key, name),
             **kwargs,
         )

--- a/common/setups/rasr/gmm_system.py
+++ b/common/setups/rasr/gmm_system.py
@@ -225,9 +225,9 @@ class GmmSystem(RasrSystem):
         :param align_iter:
         :param splits:
         :param accs_per_split:
-        :param align_keep_values:
-        :param split_keep_values:
-        :param accum_keep_values:
+        :param align_keep_values: sisyphus keep values for cleaning of alignment jobs
+        :param split_keep_values: sisyphus keep values for cleaning of split jobs
+        :param accum_keep_values: sisyphus keep values for cleaning of accumulation jobs
         :param dump_alignment_score_report: collect the alignment logs and write the report.
             please do not activate this flag if you already cleaned all alignments, as then all deleted
             jobs will re-run.
@@ -419,9 +419,9 @@ class GmmSystem(RasrSystem):
         :param initial_alignment:
         :param splits:
         :param accs_per_split:
-        :param align_keep_values:
-        :param split_keep_values:
-        :param accum_keep_values:
+        :param align_keep_values: sisyphus keep values for cleaning of alignment jobs
+        :param split_keep_values: sisyphus keep values for cleaning of split jobs
+        :param accum_keep_values: sisyphus keep values for cleaning of accumulation jobs
         :param dump_alignment_score_report: collect the alignment logs and write the report.
             please do not activate this flag if you already cleaned all alignments, as then all deleted
             jobs will re-run.
@@ -639,9 +639,9 @@ class GmmSystem(RasrSystem):
         :param feature_flow:
         :param splits:
         :param accs_per_split:
-        :param align_keep_values:
-        :param split_keep_values:
-        :param accum_keep_values:
+        :param align_keep_values: sisyphus keep values for cleaning of alignment jobs
+        :param split_keep_values: sisyphus keep values for cleaning of split jobs
+        :param accum_keep_values: sisyphus keep values for cleaning of accumulation jobs
         :param dump_alignment_score_report: collect the alignment logs and write the report.
             please do not activate this flag if you already cleaned all alignments, as then all deleted
             jobs will re-run.
@@ -828,9 +828,9 @@ class GmmSystem(RasrSystem):
         :param mixtures:
         :param splits:
         :param accs_per_split:
-        :param align_keep_values:
-        :param split_keep_values:
-        :param accum_keep_values:
+        :param align_keep_values: sisyphus keep values for cleaning of alignment jobs
+        :param split_keep_values: sisyphus keep values for cleaning of split jobs
+        :param accum_keep_values: sisyphus keep values for cleaning of accumulation jobs
         :param dump_alignment_score_report: collect the alignment logs and write the report.
             please do not activate this flag if you already cleaned all alignments, as then all deleted
             jobs will re-run.


### PR DESCRIPTION
Similar to align adds default keeps values for split and accum jobs. This does not change anything for a user that does not use keep values (they will be set but just ignored), but only introduces changes for deleting jobs with keep values.

GMMs allow to select alignments etc. those will receive the sisyphus default job value (usually 50). The non-selected jobs recieve 5 and thus can be easily deleted via sis console. Just tested this for me and "saved" 540GB on 35 GMM trainings.

Since I talked to multiple people that were not sure how to use keep values: You can simply invoke this command or similar in the sisyphus console.
``` python
tk.cleaner.cleanup_keep_value(31, mode="remove")  # (re)moves everything with keep value <= 30, allows for move/dryrun/remove
```
In general you can always also first move and then find unused directories (which then are the moved ones) to remove if you want to verify that your setup does not break during cleanup, but this ofc. also deletes other stuff which is not in the graph. 