### PR TITLE
RasrSystem: glm and stm files via scorer_args

### DIFF
--- a/common/setups/rasr/rasr_system.py
+++ b/common/setups/rasr/rasr_system.py
@@ -165,6 +165,9 @@ class RasrSystem(meta.System):
         :param eval_corpus_key:
         :return:
         """
+
+        self.glm_files.update(self.rasr_init_args.scorer_args.get("glm_files", {}))
+        self.stm_files.update(self.rasr_init_args.scorer_args.get("stm_files", {}))
         if self.rasr_init_args.scorer == "kaldi":
             scorer_args = (
                 self.rasr_init_args.scorer_args


### PR DESCRIPTION
When using the `Hub5Scorer`, it's necessary to have a glm file. Also, in the case of switchboard, we want to be able to set a custom stm file instead of one created by the `CorpusToStmJob`.

I added a small change to allow setting these via `rasr_init_args.scorer_args`. It would also be possible and maybe more canonical to allow setting glm and stm via `System.set_corpus()`. However, this is not yet implemented and also, we don't use `System.set_corpus()` in `HybridSystem`, so this would require more changes there and for the data input objects used there. Therefore, I suggest this minimal solution.