### PR TITLE
check for scorer args none

### DIFF
--- a/common/setups/rasr/rasr_system.py
+++ b/common/setups/rasr/rasr_system.py
@@ -165,9 +165,9 @@ class RasrSystem(meta.System):
         :param eval_corpus_key:
         :return:
         """
-
-        self.glm_files.update(self.rasr_init_args.scorer_args.get("glm_files", {}))
-        self.stm_files.update(self.rasr_init_args.scorer_args.get("stm_files", {}))
+        if self.rasr_init_args.scorer_args is not None:
+            self.glm_files.update(self.rasr_init_args.scorer_args.get("glm_files", {}))
+            self.stm_files.update(self.rasr_init_args.scorer_args.get("stm_files", {}))
         if self.rasr_init_args.scorer == "kaldi":
             scorer_args = (
                 self.rasr_init_args.scorer_args


### PR DESCRIPTION
#103 introduced a get on the scorer args but my (older) setup does not use them. 
Since they can be None (and cf. lines after these where this check is done too) I propose to check here aswell.