### PR TITLE
fix: Ensure calculation of center state index is bijective

### DIFF
--- a/users/raissi/setups/common/helpers/network_architectures.py
+++ b/users/raissi/setups/common/helpers/network_architectures.py
@@ -148,7 +148,7 @@ def get_common_subnetwork_for_targets_with_blstm(layers, dropout, l2, use_bounda
     else:
         if use_word_end_classes:
             acousticNet["centerState"] = {"class": "eval", "from": ["centerPhoneme", "stateId", "wordEndClass"],
-                                          "eval": f"(((source(0)*{n_states_per_phone})+source(2))*2)+source(1)",
+                                          "eval": f"(((source(0)*{n_states_per_phone})+source(1))*2)+source(2)",
                                           "register_as_extern_data": "centerState",
                                           "out_type": {'dim': n_contexts * n_states_per_phone * 2, 'dtype': 'int32',
                                                        'sparse': True}}


### PR DESCRIPTION
The calculation previously didn't yield a unique mapping of `{center phoneme, HMM state ID, WE-class} -> center state index`.

Let's discuss here if this should be merged or not.

The following table lists an overview what happens for n_contexts = 42, num_states_per_phone = 3, num_we_classes = 2. Read like `PH_ID.HMM_STATE_ID.WE_CLS/TRUE CLASS -> BUGGY CLASS`.

```
['0.0.1/1', '0.2.0/4'] -> 2
['1.0.1/7', '1.2.0/10'] -> 8
['2.0.1/13', '2.2.0/16'] -> 14
['3.0.1/19', '3.2.0/22'] -> 20
['4.0.1/25', '4.2.0/28'] -> 26
['5.0.1/31', '5.2.0/34'] -> 32
['6.0.1/37', '6.2.0/40'] -> 38
['7.0.1/43', '7.2.0/46'] -> 44
['8.0.1/49', '8.2.0/52'] -> 50
['9.0.1/55', '9.2.0/58'] -> 56
['10.0.1/61', '10.2.0/64'] -> 62
['11.0.1/67', '11.2.0/70'] -> 68
['12.0.1/73', '12.2.0/76'] -> 74
['13.0.1/79', '13.2.0/82'] -> 80
['14.0.1/85', '14.2.0/88'] -> 86
['15.0.1/91', '15.2.0/94'] -> 92
['16.0.1/97', '16.2.0/100'] -> 98
['17.0.1/103', '17.2.0/106'] -> 104
['18.0.1/109', '18.2.0/112'] -> 110
['19.0.1/115', '19.2.0/118'] -> 116
['20.0.1/121', '20.2.0/124'] -> 122
['21.0.1/127', '21.2.0/130'] -> 128
['22.0.1/133', '22.2.0/136'] -> 134
['23.0.1/139', '23.2.0/142'] -> 140
['24.0.1/145', '24.2.0/148'] -> 146
['25.0.1/151', '25.2.0/154'] -> 152
['26.0.1/157', '26.2.0/160'] -> 158
['27.0.1/163', '27.2.0/166'] -> 164
['28.0.1/169', '28.2.0/172'] -> 170
['29.0.1/175', '29.2.0/178'] -> 176
['30.0.1/181', '30.2.0/184'] -> 182
['31.0.1/187', '31.2.0/190'] -> 188
['32.0.1/193', '32.2.0/196'] -> 194
['33.0.1/199', '33.2.0/202'] -> 200
['34.0.1/205', '34.2.0/208'] -> 206
['35.0.1/211', '35.2.0/214'] -> 212
['36.0.1/217', '36.2.0/220'] -> 218
['37.0.1/223', '37.2.0/226'] -> 224
['38.0.1/229', '38.2.0/232'] -> 230
['39.0.1/235', '39.2.0/238'] -> 236
['40.0.1/241', '40.2.0/244'] -> 242
['41.0.1/247', '41.2.0/250'] -> 248
```