### PR TITLE
Hybrid updates

### DIFF
--- a/common/setups/rasr/gmm_system.py
+++ b/common/setups/rasr/gmm_system.py
@@ -1469,22 +1469,7 @@ class GmmSystem(RasrSystem):
             self.store_allophones(source_corpus=trn_c, target_corpus=trn_c)
             tk.register_output(f"{trn_c}.allophones", self.allophone_files[trn_c])
 
-        for eval_c in self.dev_corpora + self.test_corpora:
-            stm_args = (
-                self.rasr_init_args.stm_args
-                if self.rasr_init_args.stm_args is not None
-                else {}
-            )
-            self.create_stm_from_corpus(eval_c, **stm_args)
-            self._set_scorer_for_corpus(eval_c)
-
-            ppl_job = lm.ComputePerplexityJob(
-                self.crp[eval_c],
-                corpus_recipes.CorpusToTxtJob(
-                    self.crp[eval_c].corpus_config.file
-                ).out_txt,
-            )
-            tk.register_output(f"lms/{eval_c}.ppl", ppl_job.perplexity)
+        self.prepare_scoring()
 
         for step_idx, (step_name, step_args) in enumerate(steps.get_step_iter()):
             # ---------- Feature Extraction ----------

--- a/common/setups/rasr/hybrid_system.py
+++ b/common/setups/rasr/hybrid_system.py
@@ -92,7 +92,9 @@ class HybridSystem(NnSystem):
 
         self.train_input_data = None  # type:Optional[Dict[str, ReturnnRasrDataInput]]
         self.cv_input_data = None  # type:Optional[Dict[str, ReturnnRasrDataInput]]
-        self.devtrain_input_data = None  # type:Optional[Dict[str, ReturnnRasrDataInput]]
+        self.devtrain_input_data = (
+            None
+        )  # type:Optional[Dict[str, ReturnnRasrDataInput]]
         self.dev_input_data = None  # type:Optional[Dict[str, ReturnnRasrDataInput]]
         self.test_input_data = None  # type:Optional[Dict[str, ReturnnRasrDataInput]]
 

--- a/common/setups/rasr/nn_system.py
+++ b/common/setups/rasr/nn_system.py
@@ -67,7 +67,6 @@ class NnSystem(RasrSystem):
 
         self.blas_lib = blas_lib or (gs.BLAS_LIB if hasattr(gs, "BLAS_LIB") else None)
 
-
         self.native_ops = {}  # type: Dict[str, tk.Path]
 
     def compile_native_op(self, op_name: str):

--- a/common/setups/rasr/nn_system.py
+++ b/common/setups/rasr/nn_system.py
@@ -66,3 +66,35 @@ class NnSystem(RasrSystem):
         )
 
         self.blas_lib = blas_lib or (gs.BLAS_LIB if hasattr(gs, "BLAS_LIB") else None)
+
+
+        self.native_ops = {}  # type: Dict[str, tk.Path]
+
+    def compile_native_op(self, op_name: str):
+        """
+        Compiles and stores a native op for RETURNN
+
+        :param op_name: op name, e.g. "NativeLstm2"
+        """
+        native_lstm_job = returnn.CompileNativeOpJob(
+            op_name,
+            returnn_root=self.returnn_root,
+            returnn_python_exe=self.returnn_python_exe,
+            blas_lib=self.blas_lib,
+        )
+        native_lstm_job.add_alias("native_ops/compile_native_%s" % op_name)
+        self.native_ops[op_name] = native_lstm_job.out_op
+
+    def get_native_ops(self, op_names: Optional[List[str]]) -> Optional[List[tk.Path]]:
+        """
+        Access self.native_ops and compile if not existing
+
+        :param op_names: list of RETURNN op names, can be None for convenience
+        :return list of native op paths
+        """
+        if op_names is None:
+            return None
+        for op_name in op_names:
+            if op_name not in self.native_ops.keys():
+                self.compile_native_op(op_name)
+        return [self.native_ops[op_name] for op_name in op_names]

--- a/common/setups/rasr/nn_system.py
+++ b/common/setups/rasr/nn_system.py
@@ -75,14 +75,14 @@ class NnSystem(RasrSystem):
 
         :param op_name: op name, e.g. "NativeLstm2"
         """
-        native_lstm_job = returnn.CompileNativeOpJob(
+        native_op_job = returnn.CompileNativeOpJob(
             op_name,
             returnn_root=self.returnn_root,
             returnn_python_exe=self.returnn_python_exe,
             blas_lib=self.blas_lib,
         )
-        native_lstm_job.add_alias("native_ops/compile_native_%s" % op_name)
-        self.native_ops[op_name] = native_lstm_job.out_op
+        native_op_job.add_alias("native_ops/compile_native_%s" % op_name)
+        self.native_ops[op_name] = native_op_job.out_op
 
     def get_native_ops(self, op_names: Optional[List[str]]) -> Optional[List[tk.Path]]:
         """

--- a/common/setups/rasr/rasr_system.py
+++ b/common/setups/rasr/rasr_system.py
@@ -179,7 +179,7 @@ class RasrSystem(meta.System):
             )
         elif self.rasr_init_args.scorer == "hub5":
             scorer_args = (
-                scorer_args if self.rasr_init_args.scorer_args is not None else {}
+                scorer_args if scorer_args is not None else {}
             )
             self.set_hub5_scorer(corpus=eval_corpus_key, **scorer_args)
         else:

--- a/common/setups/rasr/rasr_system.py
+++ b/common/setups/rasr/rasr_system.py
@@ -169,7 +169,8 @@ class RasrSystem(meta.System):
         scorer_args = copy.deepcopy(self.rasr_init_args.scorer_args)
         if self.rasr_init_args.scorer == "kaldi":
             scorer_args = (
-                scorer_args if scorer_args is not None
+                scorer_args
+                if scorer_args is not None
                 else dict(mapping={"[SILENCE]": ""})
             )
             self.set_kaldi_scorer(
@@ -178,14 +179,12 @@ class RasrSystem(meta.System):
             )
         elif self.rasr_init_args.scorer == "hub5":
             scorer_args = (
-                scorer_args if self.rasr_init_args.scorer_args is not None
-                else {}
+                scorer_args if self.rasr_init_args.scorer_args is not None else {}
             )
             self.set_hub5_scorer(corpus=eval_corpus_key, **scorer_args)
         else:
             scorer_args = (
-                scorer_args if scorer_args is not None
-                else dict(sort_files=False)
+                scorer_args if scorer_args is not None else dict(sort_files=False)
             )
             self.set_sclite_scorer(
                 corpus=eval_corpus_key,
@@ -367,7 +366,13 @@ class RasrSystem(meta.System):
         name: str,
         *,
         target_corpus_key: str,
-        flow: Union[str, List[str], Tuple[str], rasr.FlagDependentFlowAttribute, rasr.FlowNetwork],
+        flow: Union[
+            str,
+            List[str],
+            Tuple[str],
+            rasr.FlagDependentFlowAttribute,
+            rasr.FlowNetwork,
+        ],
         feature_scorer_corpus_key: str = None,
         feature_scorer: Union[str, List[str], Tuple[str], rasr.FeatureScorer],
         scorer_index: int = -1,

--- a/common/setups/rasr/rasr_system.py
+++ b/common/setups/rasr/rasr_system.py
@@ -178,9 +178,7 @@ class RasrSystem(meta.System):
                 **scorer_args,
             )
         elif self.rasr_init_args.scorer == "hub5":
-            scorer_args = (
-                scorer_args if scorer_args is not None else {}
-            )
+            scorer_args = scorer_args if scorer_args is not None else {}
             self.set_hub5_scorer(corpus=eval_corpus_key, **scorer_args)
         else:
             scorer_args = (

--- a/common/setups/rasr/util/nn.py
+++ b/common/setups/rasr/util/nn.py
@@ -39,6 +39,8 @@ class ReturnnRasrDataInput:
         acoustic_mixtures: Optional[Union[tk.Path, str]] = None,
         feature_scorers: Optional[Dict[str, Type[rasr.FeatureScorer]]] = None,
         shuffle_data: bool = True,
+        stm: Optional[tk.Path] = None,
+        glm: Optional[tk.Path] = None,
         **kwargs,
     ):
         self.name = name
@@ -49,6 +51,8 @@ class ReturnnRasrDataInput:
         self.acoustic_mixtures = acoustic_mixtures
         self.feature_scorers = feature_scorers
         self.shuffle_data = shuffle_data
+        self.stm = stm
+        self.glm = glm
 
     @staticmethod
     def get_data_dict():
@@ -342,6 +346,7 @@ class NnRecogArgs:
     mem: int
     lookahead_options: Optional[Dict] = None
     epochs: Optional[List[int]] = None
+    native_ops: Optional[List[str]] = None
 
 
 class NnForcedAlignArgs(TypedDict):

--- a/common/setups/rasr/util/rasr.py
+++ b/common/setups/rasr/util/rasr.py
@@ -8,6 +8,7 @@ __all__ = [
 
 from collections import OrderedDict
 from typing import Dict, Optional
+from sisyphus import tk
 
 import i6_core.meta as meta
 
@@ -27,17 +28,23 @@ class RasrDataInput:
         lexicon: dict,
         lm: Optional[dict] = None,
         concurrent: int = 10,
+        stm: Optional[tk.Path] = None,
+        glm: Optional[tk.Path] = None,
     ):
         """
         :param corpus_object: corpus_file: Path, audio_dir: Path, audio_format: str, duration: float
         :param lexicon: file: Path, normalize_pronunciation: bool
         :param lm: filename: Path, type: str, scale: float
         :param concurrent: concurrency for gmm hmm pipeline
+        :param stm: optional stm file for evaluation
+        :param glm: optional glm file for evaluation
         """
         self.corpus_object = corpus_object
         self.lexicon = lexicon
         self.lm = lm
         self.concurrent = concurrent
+        self.stm = stm
+        self.glm = glm
 
 
 class RasrInitArgs:


### PR DESCRIPTION
 - support for stm and glm in via data (used for Switchboard setup)
 - NnSystem manages native op compilation
 - small refactoring of evaluation preparation
 - removes compute perplexity
 
 Note: Any recognition args now need to have `"native_ops": ["NativeLstm2"]` to get the old behavior.