### PR TITLE
Bug for GMM system for decoding with test

### DIFF
--- a/common/setups/rasr/gmm_system.py
+++ b/common/setups/rasr/gmm_system.py
@@ -1296,6 +1296,7 @@ class GmmSystem(RasrSystem):
                 self.sat_recognition(
                     name=f"{trn_c}-{name}",
                     corpus_key=tst_c,
+                    train_corpus_key=trn_c,
                     feature_scorer_key=feature_scorer,
                     **recog_args,
                 )
@@ -1336,6 +1337,7 @@ class GmmSystem(RasrSystem):
                 self.sat_recognition(
                     name=f"{trn_c}-{name}",
                     corpus_key=tst_c,
+                    train_corpus_key=trn_c,
                     feature_scorer_key=feature_scorer,
                     **recog_args,
                 )


### PR DESCRIPTION
When calling `sat_recognition()` one need to pass the `train_corpus_key`.