### PR TITLE
add SMS-WSJ RETURNN datasets

### DIFF
--- a/common/datasets/sms_wsj/returnn_datasets.py
+++ b/common/datasets/sms_wsj/returnn_datasets.py
@@ -283,9 +283,7 @@ class SmsWsjBaseWithRasrClasses(SmsWsjBase):
         """
         super(SmsWsjBaseWithRasrClasses, self).__init__(**kwargs)
 
-        self._rasr_classes_hdf = HDFDataset(
-            [rasr_classes_hdf], use_cache_manager=True
-        )
+        self._rasr_classes_hdf = HDFDataset([rasr_classes_hdf], use_cache_manager=True)
         self._segment_to_rasr = segment_to_rasr
         self._pad_label = pad_label
         self._hdf_data_key = hdf_data_key
@@ -293,20 +291,17 @@ class SmsWsjBaseWithRasrClasses(SmsWsjBase):
     def __getitem__(self, seq_idx: int) -> Dict[str, np.array]:
         d = self._get_seq_by_idx(seq_idx)
         rasr_seq_tags = self._segment_to_rasr(d["seq_tag"])
-        assert len(rasr_seq_tags) == d["target_signals"].shape[1], (
-            f"got {len(rasr_seq_tags)} segment names, but there are {d['target_signals'].shape[1]} target signals")
+        assert (
+            len(rasr_seq_tags) == d["target_signals"].shape[1]
+        ), f"got {len(rasr_seq_tags)} segment names, but there are {d['target_signals'].shape[1]} target signals"
         rasr_targets = [
             self._rasr_classes_hdf.get_data_by_seq_tag(rasr_seq_tag, self._hdf_data_key)
             for rasr_seq_tag in rasr_seq_tags
         ]
-        padded_len = max(
-            rasr_target.shape[0] for rasr_target in rasr_targets
-        )
+        padded_len = max(rasr_target.shape[0] for rasr_target in rasr_targets)
         for speaker_idx in range(len(rasr_targets)):
             pad_start = int(round(d["offset"][speaker_idx] / d["seq_len"] * padded_len))
-            pad_end = (
-                padded_len - rasr_targets[speaker_idx].shape[0] - pad_start
-            )
+            pad_end = padded_len - rasr_targets[speaker_idx].shape[0] - pad_start
             if pad_end < 0:
                 pad_start += pad_end
                 assert pad_start >= 0

--- a/common/datasets/sms_wsj/returnn_datasets.py
+++ b/common/datasets/sms_wsj/returnn_datasets.py
@@ -1,0 +1,411 @@
+"""
+Dataset wrapper to allow using the SMS-WSJ dataset in RETURNN.
+"""
+
+import functools
+import json
+import numpy as np
+import os.path
+import subprocess as sp
+from typing import Dict, Tuple, Any, Optional
+# noinspection PyUnresolvedReferences
+from returnn.datasets.basic import DatasetSeq
+# noinspection PyUnresolvedReferences
+from returnn.datasets.hdf import HDFDataset
+# noinspection PyUnresolvedReferences
+from returnn.datasets.map import MapDatasetBase, MapDatasetWrapper
+# noinspection PyUnresolvedReferences
+from returnn.log import log
+# noinspection PyUnresolvedReferences
+from returnn.util.basic import OptionalNotImplementedError, NumbersDict
+# noinspection PyUnresolvedReferences
+from sms_wsj.database import SmsWsj, AudioReader, scenario_map_fn
+
+
+class SmsWsjBase(MapDatasetBase):
+  """
+  Base class to wrap the SMS-WSJ dataset. This is not the dataset that is used in the RETURNN config, see
+  ``SmsWsjWrapper`` and derived classes for that.
+  """
+
+  def __init__(
+    self, dataset_name, json_path, pre_batch_transform, buffer=True, zip_cache=None, scenario_map_args=None, **kwargs
+  ):
+    """
+    :param str dataset_name: "train_si284", "cv_dev93" or "test_eval92"
+    :param str json_path: path to SMS-WSJ json file
+    :param function pre_batch_transform: function which processes raw SMS-WSJ data
+    :param bool buffer: if True, use SMS-WSJ dataset prefetching and store sequences in buffer
+    :param Optional[str] zip_cache: zip archive with SMS-WSJ data which can be cached, unzipped and used as data dir
+    :param Optional[Dict] scenario_map_args: optional kwargs for sms_wsj scenario_map_fn
+    """
+    super(SmsWsjBase, self).__init__(**kwargs)
+
+    if zip_cache is not None:
+      self._cache_zipped_audio(zip_cache, json_path, dataset_name)
+
+    db = SmsWsj(json_path=json_path)
+    ds = db.get_dataset(dataset_name)
+    ds = ds.map(AudioReader(("original_source", "rir")))
+
+    scenario_map_args = {
+      "add_speech_image": False,
+      "add_speech_reverberation_early": False,
+      "add_speech_reverberation_tail": False,
+      "add_noise_image": False,
+      **(scenario_map_args or {})}
+    ds = ds.map(functools.partial(scenario_map_fn, **scenario_map_args))
+    ds = ds.map(functools.partial(pre_batch_transform))
+
+    self._ds = ds
+    self._ds_iterator = iter(self._ds)
+
+    self._use_buffer = buffer
+    if self._use_buffer:
+      self._ds = self._ds.prefetch(4, 8).copy(freeze=True)
+    self._buffer = {}  # type Dict[int,[Dict[str,np.array]]]
+    self._buffer_size = 40
+
+  def __len__(self) -> int:
+    return len(self._ds)
+
+  def __getitem__(self, seq_idx: int) -> Dict[str, np.array]:
+    return self._get_seq_by_idx(seq_idx)
+
+  def _get_seq_by_idx(self, seq_idx: int) -> Dict[str, np.array]:
+    """
+    Returns data for sequence index.
+    """
+    if self._use_buffer:
+      assert seq_idx in self._buffer, f"seq_idx {seq_idx} not in buffer. Available keys are {self._buffer.keys()}"
+      return self._buffer[seq_idx]
+    else:
+      return self._ds[seq_idx]
+
+  def get_seq_tag(self, seq_idx: int) -> str:
+    """
+    Returns tag for the sequence of the given index, default is 'seq-{seq_idx}'.
+    """
+    if "seq_tag" in self._get_seq_by_idx(seq_idx):
+      return str(self._get_seq_by_idx(seq_idx)["seq_tag"])
+    else:
+      return "seq-%i" % seq_idx
+
+  def get_seq_len(self, seq_idx: int) -> int:
+    """
+    Returns length of the sequence of the given index
+    """
+    if "seq_len" in self._get_seq_by_idx(seq_idx):
+      return int(self._get_seq_by_idx(seq_idx)["seq_len"])
+    else:
+      raise OptionalNotImplementedError
+
+  def get_seq_length_for_keys(self, seq_idx: int) -> NumbersDict:
+    """
+    Returns sequence length for all data/target keys.
+    """
+    data = self[seq_idx]
+    d = {k: v.size for k, v in data.items()}
+    for update_key in ["data", "target_signals"]:
+      if update_key in d.keys() and "seq_len" in data:
+        d[update_key] = int(data["seq_len"])
+    return NumbersDict(d)
+
+  def update_buffer(self, seq_idx: int, pop_seqs: bool = True):
+    """
+    :param int seq_idx:
+    :param bool pop_seqs: if True, pop sequences from buffer that are outside buffer range
+    """
+    if not self._use_buffer:
+      return
+
+    # debugging information
+    keys = list(self._buffer.keys()) or [0]
+    if not (min(keys) <= seq_idx <= max(keys)):
+      print(f"WARNING: seq_idx {seq_idx} outside range of keys: {self._buffer.keys()}")
+
+    # add sequences
+    for idx in range(seq_idx, min(seq_idx + self._buffer_size // 2, len(self))):
+      if idx not in self._buffer and idx < len(self):
+        try:
+          self._buffer[idx] = next(self._ds_iterator)
+        except StopIteration:
+          print(f"StopIteration for seq_idx {seq_idx}")
+          print(f"Dataset: {self} with SMS-WSJ {self._ds} of len {len(self)}")
+          print(f"Indices in buffer: {self._buffer.keys()}")
+          # raise
+          print(f"WARNING: Ignoring this, reset iterator and continue")
+          self._ds_iterator = iter(self._ds)
+          self._buffer[idx] = next(self._ds_iterator)
+      if idx == len(self) - 1 and 0 not in self._buffer:
+        print(f"Reached end of dataset, reset iterator")
+        try:
+          next(self._ds_iterator)
+        except StopIteration:
+          pass
+        else:
+          print(
+            "WARNING: reached final index of dataset, but iterator has more sequences. "
+            "Maybe the training was restarted from an epoch > 1?")
+        print(f"Current buffer indices: {self._buffer.keys()}")
+        self._ds_iterator = iter(self._ds)
+        for idx_ in range(self._buffer_size // 2):
+          if idx_ not in self._buffer and idx_ < len(self):
+            self._buffer[idx_] = next(self._ds_iterator)
+        print(f"After adding start of dataset to buffer indices: {self._buffer.keys()}")
+
+    # remove sequences
+    if pop_seqs:
+      for idx in list(self._buffer):
+        if not (seq_idx - self._buffer_size // 2 <= idx <= seq_idx + self._buffer_size // 2):
+          if max(self._buffer.keys()) == len(self) - 1 and idx < self._buffer_size // 2:
+            # newly added sequences starting from 0
+            continue
+          self._buffer.pop(idx)
+
+  @staticmethod
+  def _cache_zipped_audio(zip_cache: str, json_path: str, dataset_name: str):
+    """
+    Caches and unzips a given archive with SMS-WSJ data which will then be used as data dir.
+    This is done because caching of the single files takes extremely long.
+    """
+    print(f"Cache and unzip SMS-WSJ data from {zip_cache}")
+
+    # cache and unzip
+    try:
+      zip_cache_cached = sp.check_output(["cf", zip_cache]).strip().decode("utf8")
+      assert zip_cache_cached != zip_cache, "cached and original file have the same path"
+      local_unzipped_dir = os.path.dirname(zip_cache_cached)
+      sp.check_call(["unzip", "-q", "-n", zip_cache_cached, "-d", local_unzipped_dir])
+    except sp.CalledProcessError:
+      print(f"Cache manager: Error occurred when caching and unzipping {zip_cache}")
+      raise
+
+    # modify json and check if all data is available
+    with open(json_path, "r") as f:
+      json_dict = json.loads(f.read())
+    original_dir = next(iter(json_dict["datasets"][dataset_name].values()))["audio_path"]["original_source"][0]
+    while not original_dir.endswith(os.path.basename(local_unzipped_dir)) and len(original_dir) > 1:
+      original_dir = os.path.dirname(original_dir)
+    for seq in json_dict["datasets"][dataset_name]:
+      for audio_key in ["original_source", "rir"]:
+        for seq_idx in range(len(json_dict["datasets"][dataset_name][seq]["audio_path"][audio_key])):
+          path = json_dict["datasets"][dataset_name][seq]["audio_path"][audio_key][seq_idx]
+          path = path.replace(original_dir, local_unzipped_dir)
+          json_dict["datasets"][dataset_name][seq]["audio_path"][audio_key][seq_idx] = path
+          assert path.startswith(local_unzipped_dir), (
+            f"Audio file {path} was expected to start with {local_unzipped_dir}")
+          assert os.path.exists(path), f"Audio file {path} does not exist"
+
+    json_path = os.path.join(local_unzipped_dir, "sms_wsj.json")
+    with open(json_path, "w", encoding="utf-8") as f:
+      json.dump(json_dict, f, ensure_ascii=False, indent=4)
+
+    print(f"Finished preparation of zip cache data, use json in {json_path}")
+
+
+class SmsWsjBaseWithRasrClasses(SmsWsjBase):
+  """
+  Base class to wrap the SMS-WSJ dataset and combine it with RASR alignments in an hdf dataset.
+  """
+
+  def __init__(
+      self, rasr_classes_hdf=None, rasr_corpus=None, rasr_segment_prefix="", rasr_segment_postfix="", **kwargs
+  ):
+    """
+    :param Optional[str] rasr_classes_hdf: hdf file with dumped RASR class labels
+    :param Optional[str] rasr_corpus: RASR corpus file for reading segment start and end times for padding
+    :param str rasr_segment_prefix: prefix to map SMS-WSJ segment name to RASR segment name
+    :param str rasr_segment_postfix: postfix to map SMS-WSJ segment name to RASR segment name
+    :param kwargs:
+    """
+    super(SmsWsjBaseWithRasrClasses, self).__init__(**kwargs)
+
+    # self.data_types = {"target_signals": {"dim": 2, "shape": (None, 2)}}
+    self._rasr_classes_hdf = None
+    if rasr_classes_hdf is not None:
+      self._rasr_classes_hdf = HDFDataset([rasr_classes_hdf], use_cache_manager=True)
+      # self.data_types["target_rasr"] = {"sparse": True, "dim": 9001, "shape": (None, 2)}
+    self._rasr_segment_start_end = {}  # type: Dict[str, Tuple[float, float]]
+    if rasr_corpus is not None:
+      from i6_core.lib.corpus import Corpus
+      corpus = Corpus()
+      corpus.load(rasr_corpus)
+      for seg in corpus.segments():
+        self._rasr_segment_start_end[seg.fullname()] = (seg.start, seg.end)
+    self.rasr_segment_prefix = rasr_segment_prefix
+    self.rasr_segment_postfix = rasr_segment_postfix
+
+  def __getitem__(self, seq_idx: int) -> Dict[str, np.array]:
+    d = self._get_seq_by_idx(seq_idx)
+    if self._rasr_classes_hdf is not None:
+      rasr_seq_tags = [
+        f"{self.rasr_segment_prefix}{d['seq_tag']}_{speaker}{self.rasr_segment_postfix}"
+        for speaker in range(d["target_signals"].shape[1])]
+      rasr_targets = []
+      for idx, rasr_seq_tag in enumerate(rasr_seq_tags):
+        rasr_targets.append(self._rasr_classes_hdf.get_data_by_seq_tag(rasr_seq_tag, "classes"))
+      start_end_times = [self._rasr_segment_start_end.get(rasr_seq_tag, (0, 0)) for rasr_seq_tag in rasr_seq_tags]
+      padded_len_sec = max(start_end[1] for start_end in start_end_times)
+      padded_len_frames = max(rasr_target.shape[0] for rasr_target in rasr_targets)
+      for speaker_idx in range(len(rasr_targets)):
+        pad_start = 0
+        if padded_len_sec > 0:
+          pad_start = round(start_end_times[speaker_idx][0] / padded_len_sec * padded_len_frames)
+        pad_end = padded_len_frames - rasr_targets[speaker_idx].shape[0] - pad_start
+        if pad_end < 0:
+          pad_start += pad_end
+          assert pad_start >= 0
+          pad_end = 0
+        rasr_targets[speaker_idx] = np.concatenate([
+          9000 * np.ones(pad_start), rasr_targets[speaker_idx], 9000 * np.ones(pad_end)])
+      d["target_rasr"] = np.stack(rasr_targets).T
+      d["target_rasr_len"] = np.array(padded_len_frames)
+    return d
+
+  def get_seq_length_for_keys(self, seq_idx: int) -> NumbersDict:
+    """
+    Returns sequence length for all data/target keys.
+    """
+    d = super(SmsWsjBaseWithRasrClasses, self).get_seq_length_for_keys(seq_idx)
+    data = self[seq_idx]
+    d["target_rasr"] = int(data["target_rasr_len"])
+    return NumbersDict(d)
+
+
+class SmsWsjWrapper(MapDatasetWrapper):
+  """
+  Base class for datasets that can be used in RETURNN config.
+  """
+
+  def __init__(
+      self, sms_wsj_base, **kwargs
+  ):
+    """
+    :param Optional[SmsWsjBase] sms_wsj_base: SMS-WSJ base class to allow inherited classes to modify this
+    """
+    if "seq_ordering" not in kwargs:
+      print("Warning: no shuffling is enabled by default", file=log.v)
+    super(SmsWsjWrapper, self).__init__(sms_wsj_base, **kwargs)
+    # self.num_outputs = ...  # needs to be set in derived classes
+
+    def _get_seq_length(seq_idx: int) -> NumbersDict:
+      """
+      Returns sequence length for all data/target keys.
+      """
+      corpus_seq_idx = self.get_corpus_seq_idx(seq_idx)
+      return sms_wsj_base.get_seq_length_for_keys(corpus_seq_idx)
+
+    self.get_seq_length = _get_seq_length
+
+  @staticmethod
+  def _pre_batch_transform(inputs: Dict[str, Any]) -> Dict[str, np.array]:
+    """
+    Used to process raw SMS-WSJ data
+    :param  inputs: input as coming from SMS-WSJ
+    """
+    return_dict = {
+      "seq_tag": np.array(inputs["example_id"], dtype=object),
+      "source_id": np.array(inputs["source_id"], dtype=object),
+      "seq_len": np.array(inputs["num_samples"]["observation"]),
+    }
+    return return_dict
+
+  def _collect_single_seq(self, seq_idx: int) -> DatasetSeq:
+    """
+    :param seq_idx: sorted seq idx
+    """
+    corpus_seq_idx = self.get_corpus_seq_idx(seq_idx)
+    self._dataset.update_buffer(corpus_seq_idx)
+    data = self._dataset[corpus_seq_idx]
+    assert "seq_tag" in data
+    return DatasetSeq(seq_idx, features=data, seq_tag=data["seq_tag"])
+
+  def init_seq_order(self, epoch: Optional[int] = None, **kwargs) -> bool:
+    """
+    Override this in order to update the buffer. get_seq_length is often called before _collect_single_seq, therefore
+    the buffer does not contain the initial indices when continuing the training from an epoch > 0.
+    """
+    out = super(SmsWsjWrapper, self).init_seq_order(epoch=epoch, **kwargs)
+    buffer_index = ((epoch or 1) - 1) * self.num_seqs % len(self._dataset)
+    self._dataset.update_buffer(buffer_index, pop_seqs=False)
+    return out
+
+
+class SmsWsjMixtureEarlyDataset(SmsWsjWrapper):
+  """
+  Dataset with audio mixture and early signals as target.
+  """
+
+  def __init__(
+      self, dataset_name, json_path, num_outputs=None, zip_cache=None, sms_wsj_base=None, **kwargs
+  ):
+    """
+    :param str dataset_name: "train_si284", "cv_dev93" or "test_eval92"
+    :param str json_path: path to SMS-WSJ json file
+    :param Optional[Dict[str, List[int]]] num_outputs: num_outputs for RETURNN dataset
+    :param Optional[str] zip_cache: zip archive with SMS-WSJ data which can be cached, unzipped and used as data dir
+    :param Optional[SmsWsjBase] sms_wsj_base: SMS-WSJ base class to allow inherited classes to modify this
+    """
+    if sms_wsj_base is None:
+      sms_wsj_base = SmsWsjBase(
+        dataset_name=dataset_name,
+        json_path=json_path,
+        pre_batch_transform=self._pre_batch_transform,
+        scenario_map_args={"add_speech_reverberation_early": True},
+        zip_cache=zip_cache)
+    super(SmsWsjMixtureEarlyDataset, self).__init__(sms_wsj_base, **kwargs)
+    # typically data is raw waveform so 1-D and dense, target signals are 2-D (one for each speaker) and dense
+    self.num_outputs = num_outputs or {"data": [1, 2], "target_signals": [2, 2]}
+
+  @staticmethod
+  def _pre_batch_transform(inputs: Dict[str, Any]) -> Dict[str, np.array]:
+    """
+    Used to process raw SMS-WSJ data
+    :param inputs: input as coming from SMS-WSJ
+    """
+    return_dict = SmsWsjWrapper._pre_batch_transform(inputs)
+    return_dict.update({
+      "data": inputs["audio_data"]["observation"][:1, :].T,  # take first of 6 channels: (T, 1)
+      "target_signals": inputs["audio_data"]["speech_reverberation_early"][:, 0, :].T,  # first of 6 channels: (T, S)
+    })
+    return return_dict
+
+
+class SmsWsjMixtureEarlyAlignmentDataset(SmsWsjMixtureEarlyDataset):
+  """
+  Dataset with audio mixture, target early signals and target RASR alignments.
+  """
+
+  def __init__(
+      self, dataset_name, json_path, num_outputs=None, rasr_num_outputs=None, rasr_segment_prefix="",
+      rasr_segment_postfix="", rasr_classes_hdf=None, rasr_corpus=None, zip_cache=None, **kwargs
+  ):
+    """
+    :param str dataset_name: "train_si284", "cv_dev93" or "test_eval92"
+    :param str json_path: path to SMS-WSJ json file
+    :param Optional[Dict[str, List[int]]] num_outputs: num_outputs for RETURNN dataset
+    :param Optional[int] rasr_num_outputs: number of output labels for RASR alignment, e.g. 9001 for that CART size
+    :param str rasr_segment_prefix: prefix to map SMS-WSJ segment name to RASR segment name
+    :param str rasr_segment_postfix: postfix to map SMS-WSJ segment name to RASR segment name
+    :param str rasr_classes_hdf: hdf file with dumped RASR class labels
+    :param str rasr_corpus: RASR corpus file for reading segment start and end times for padding
+    :param Optional[str] zip_cache: zip archive with SMS-WSJ data which can be cached, unzipped and used as data dir
+    """
+    sms_wsj_base = SmsWsjBaseWithRasrClasses(
+      dataset_name=dataset_name,
+      json_path=json_path,
+      pre_batch_transform=self._pre_batch_transform,
+      scenario_map_args={"add_speech_reverberation_early": True},
+      rasr_classes_hdf=rasr_classes_hdf,
+      rasr_corpus=rasr_corpus,
+      rasr_segment_prefix=rasr_segment_prefix,
+      rasr_segment_postfix=rasr_segment_postfix,
+      zip_cache=zip_cache)
+    super(SmsWsjMixtureEarlyAlignmentDataset, self).__init__(
+      dataset_name, json_path, num_outputs=num_outputs, zip_cache=zip_cache, sms_wsj_base=sms_wsj_base, **kwargs)
+    if num_outputs is not None:
+      self.num_outputs = num_outputs
+    else:
+      assert rasr_num_outputs is not None, "either num_outputs or rasr_num_outputs has to be given"
+      self.num_outputs["target_rasr"] = [rasr_num_outputs, 1]  # target alignments are sparse with the given dim

--- a/common/datasets/sms_wsj/returnn_datasets.py
+++ b/common/datasets/sms_wsj/returnn_datasets.py
@@ -105,6 +105,7 @@ class SmsWsjBase(MapDatasetBase):
         buffer=True,
         buffer_size=40,
         prefetch_num_workers=4,
+        prefetch_buffer_size=8,
     ):
         """
         :param str dataset_name: "train_si284", "cv_dev93" or "test_eval92"
@@ -117,6 +118,7 @@ class SmsWsjBase(MapDatasetBase):
         :param bool buffer: if True, use SMS-WSJ dataset prefetching and store sequences in buffer
         :param int buffer_size: buffer size, should always be larger than 2 * number of sequences in a batch
         :param int prefetch_num_workers: number of workers for prefetching
+        :param int prefetch_buffer_size: buffer size for prefetching
         """
 
         super().__init__(data_types=num_outputs)
@@ -158,7 +160,7 @@ class SmsWsjBase(MapDatasetBase):
 
         self._use_buffer = buffer
         if self._use_buffer:
-            self._ds = self._ds.prefetch(prefetch_num_workers, buffer_size).copy(
+            self._ds = self._ds.prefetch(prefetch_num_workers, prefetch_buffer_size).copy(
                 freeze=True
             )
         self._buffer = SequenceBuffer(buffer_size)

--- a/common/datasets/sms_wsj/returnn_datasets.py
+++ b/common/datasets/sms_wsj/returnn_datasets.py
@@ -144,7 +144,8 @@ class SmsWsjBase(MapDatasetBase):
         keys = list(self._buffer.keys()) or [0]
         if not (min(keys) <= seq_idx <= max(keys)):
             print(
-                f"WARNING: seq_idx {seq_idx} outside range of keys: {self._buffer.keys()}"
+                f"WARNING: seq_idx {seq_idx} outside range of keys: {self._buffer.keys()}",
+                file=log.v5
             )
 
         # add sequences
@@ -152,7 +153,7 @@ class SmsWsjBase(MapDatasetBase):
             if idx not in self._buffer:
                 self._buffer[idx] = next(self._ds_iterator)
             if idx == len(self) - 1 and 0 not in self._buffer:
-                print(f"Reached end of dataset, reset iterator")
+                print(f"Reached end of dataset, reset iterator", file=log.v4)
                 try:
                     next(self._ds_iterator)
                 except StopIteration:
@@ -160,15 +161,17 @@ class SmsWsjBase(MapDatasetBase):
                 else:
                     print(
                         "WARNING: reached final index of dataset, but iterator has more sequences. "
-                        "Maybe the training was restarted from an epoch > 1?"
+                        "Maybe the training was restarted from an epoch > 1?",
+                        file=log.v3
                     )
-                print(f"Current buffer indices: {self._buffer.keys()}")
+                print(f"Current buffer indices: {self._buffer.keys()}", file=log.v5)
                 self._ds_iterator = iter(self._ds)
                 for idx_ in range(min(self._buffer_size // 2, len(self))):
                     if idx_ not in self._buffer:
                         self._buffer[idx_] = next(self._ds_iterator)
                 print(
-                    f"After adding start of dataset to buffer indices: {self._buffer.keys()}"
+                    f"After adding start of dataset to buffer indices: {self._buffer.keys()}",
+                    file=log.v5
                 )
 
         # remove sequences
@@ -193,7 +196,7 @@ class SmsWsjBase(MapDatasetBase):
         Caches and unzips a given archive with SMS-WSJ data which will then be used as data dir.
         This is done because caching of the single files takes extremely long.
         """
-        print(f"Cache and unzip SMS-WSJ data from {zip_cache}")
+        print(f"Cache and unzip SMS-WSJ data from {zip_cache}", file=log.v4)
 
         # cache file
         try:
@@ -208,7 +211,8 @@ class SmsWsjBase(MapDatasetBase):
             ), "cached and original file have the same path"
         except sp.CalledProcessError:
             print(
-                f"Cache manager: Error occurred when caching and unzipping {zip_cache}"
+                f"Cache manager: Error occurred when caching and unzipping {zip_cache}",
+                file=log.v2
             )
             raise
 
@@ -218,7 +222,7 @@ class SmsWsjBase(MapDatasetBase):
                 ["unzip", "-q", "-n", zip_cache_cached, "-d", local_unzipped_dir]
             )
         else:
-            print(f"Unzipped audio already exists in {local_unzipped_dir}")
+            print(f"Unzipped audio already exists in {local_unzipped_dir}", file=log.v4)
 
         json_path_cached_mod = json_path_cached.replace(".json", ".mod.json")
         original_dir = None
@@ -266,7 +270,8 @@ class SmsWsjBase(MapDatasetBase):
                 json.dump(json_dict, f, ensure_ascii=False, indent=4)
 
         print(
-            f"Finished preparation of zip cache data, use json in {json_path_cached_mod}"
+            f"Finished preparation of zip cache data, use json in {json_path_cached_mod}",
+            file=log.v4
         )
         return json_path_cached_mod
 
@@ -349,7 +354,7 @@ class SmsWsjWrapper(MapDatasetWrapper):
         :param Optional[SmsWsjBase] sms_wsj_base: SMS-WSJ base class to allow inherited classes to modify this
         """
         if "seq_ordering" not in kwargs:
-            print("Warning: no shuffling is enabled by default", file=log.v)
+            print("Warning: no shuffling is enabled by default", file=log.v2)
         super().__init__(sms_wsj_base, **kwargs)
         # self.num_outputs = ...  # needs to be set in derived classes
 

--- a/common/datasets/sms_wsj/returnn_datasets.py
+++ b/common/datasets/sms_wsj/returnn_datasets.py
@@ -414,7 +414,7 @@ class SmsWsjMixtureEarlyDataset(SmsWsjWrapper):
                 zip_cache=zip_cache,
                 data_types={"target_signals": {"dim": 2, "shape": (None, 2)}},
             )
-        super(SmsWsjMixtureEarlyDataset, self).__init__(sms_wsj_base, **kwargs)
+        super().__init__(sms_wsj_base, **kwargs)
         # typically data is raw waveform so 1-D and dense, target signals are 2-D (one for each speaker) and dense
         self.num_outputs = num_outputs or {"data": [1, 2], "target_signals": [2, 2]}
 

--- a/common/datasets/sms_wsj/returnn_datasets.py
+++ b/common/datasets/sms_wsj/returnn_datasets.py
@@ -8,404 +8,513 @@ import numpy as np
 import os.path
 import subprocess as sp
 from typing import Dict, Tuple, Any, Optional
+
 # noinspection PyUnresolvedReferences
 from returnn.datasets.basic import DatasetSeq
+
 # noinspection PyUnresolvedReferences
 from returnn.datasets.hdf import HDFDataset
+
 # noinspection PyUnresolvedReferences
 from returnn.datasets.map import MapDatasetBase, MapDatasetWrapper
+
 # noinspection PyUnresolvedReferences
 from returnn.log import log
+
 # noinspection PyUnresolvedReferences
 from returnn.util.basic import OptionalNotImplementedError, NumbersDict
+
 # noinspection PyUnresolvedReferences
 from sms_wsj.database import SmsWsj, AudioReader, scenario_map_fn
 
 
 class SmsWsjBase(MapDatasetBase):
-  """
-  Base class to wrap the SMS-WSJ dataset. This is not the dataset that is used in the RETURNN config, see
-  ``SmsWsjWrapper`` and derived classes for that.
-  """
-
-  def __init__(
-    self, dataset_name, json_path, pre_batch_transform, buffer=True, zip_cache=None, scenario_map_args=None, **kwargs
-  ):
     """
-    :param str dataset_name: "train_si284", "cv_dev93" or "test_eval92"
-    :param str json_path: path to SMS-WSJ json file
-    :param function pre_batch_transform: function which processes raw SMS-WSJ data
-    :param bool buffer: if True, use SMS-WSJ dataset prefetching and store sequences in buffer
-    :param Optional[str] zip_cache: zip archive with SMS-WSJ data which can be cached, unzipped and used as data dir
-    :param Optional[Dict] scenario_map_args: optional kwargs for sms_wsj scenario_map_fn
+    Base class to wrap the SMS-WSJ dataset. This is not the dataset that is used in the RETURNN config, see
+    ``SmsWsjWrapper`` and derived classes for that.
     """
-    super(SmsWsjBase, self).__init__(**kwargs)
 
-    if zip_cache is not None:
-      self._cache_zipped_audio(zip_cache, json_path, dataset_name)
+    def __init__(
+        self,
+        dataset_name,
+        json_path,
+        pre_batch_transform,
+        buffer=True,
+        zip_cache=None,
+        scenario_map_args=None,
+        **kwargs,
+    ):
+        """
+        :param str dataset_name: "train_si284", "cv_dev93" or "test_eval92"
+        :param str json_path: path to SMS-WSJ json file
+        :param function pre_batch_transform: function which processes raw SMS-WSJ data
+        :param bool buffer: if True, use SMS-WSJ dataset prefetching and store sequences in buffer
+        :param Optional[str] zip_cache: zip archive with SMS-WSJ data which can be cached, unzipped and used as data dir
+        :param Optional[Dict] scenario_map_args: optional kwargs for sms_wsj scenario_map_fn
+        """
+        super(SmsWsjBase, self).__init__(**kwargs)
 
-    db = SmsWsj(json_path=json_path)
-    ds = db.get_dataset(dataset_name)
-    ds = ds.map(AudioReader(("original_source", "rir")))
+        if zip_cache is not None:
+            self._cache_zipped_audio(zip_cache, json_path, dataset_name)
 
-    scenario_map_args = {
-      "add_speech_image": False,
-      "add_speech_reverberation_early": False,
-      "add_speech_reverberation_tail": False,
-      "add_noise_image": False,
-      **(scenario_map_args or {})}
-    ds = ds.map(functools.partial(scenario_map_fn, **scenario_map_args))
-    ds = ds.map(functools.partial(pre_batch_transform))
+        db = SmsWsj(json_path=json_path)
+        ds = db.get_dataset(dataset_name)
+        ds = ds.map(AudioReader(("original_source", "rir")))
 
-    self._ds = ds
-    self._ds_iterator = iter(self._ds)
+        scenario_map_args = {
+            "add_speech_image": False,
+            "add_speech_reverberation_early": False,
+            "add_speech_reverberation_tail": False,
+            "add_noise_image": False,
+            **(scenario_map_args or {}),
+        }
+        ds = ds.map(functools.partial(scenario_map_fn, **scenario_map_args))
+        ds = ds.map(functools.partial(pre_batch_transform))
 
-    self._use_buffer = buffer
-    if self._use_buffer:
-      self._ds = self._ds.prefetch(4, 8).copy(freeze=True)
-    self._buffer = {}  # type Dict[int,[Dict[str,np.array]]]
-    self._buffer_size = 40
-
-  def __len__(self) -> int:
-    return len(self._ds)
-
-  def __getitem__(self, seq_idx: int) -> Dict[str, np.array]:
-    return self._get_seq_by_idx(seq_idx)
-
-  def _get_seq_by_idx(self, seq_idx: int) -> Dict[str, np.array]:
-    """
-    Returns data for sequence index.
-    """
-    if self._use_buffer:
-      assert seq_idx in self._buffer, f"seq_idx {seq_idx} not in buffer. Available keys are {self._buffer.keys()}"
-      return self._buffer[seq_idx]
-    else:
-      return self._ds[seq_idx]
-
-  def get_seq_tag(self, seq_idx: int) -> str:
-    """
-    Returns tag for the sequence of the given index, default is 'seq-{seq_idx}'.
-    """
-    if "seq_tag" in self._get_seq_by_idx(seq_idx):
-      return str(self._get_seq_by_idx(seq_idx)["seq_tag"])
-    else:
-      return "seq-%i" % seq_idx
-
-  def get_seq_len(self, seq_idx: int) -> int:
-    """
-    Returns length of the sequence of the given index
-    """
-    if "seq_len" in self._get_seq_by_idx(seq_idx):
-      return int(self._get_seq_by_idx(seq_idx)["seq_len"])
-    else:
-      raise OptionalNotImplementedError
-
-  def get_seq_length_for_keys(self, seq_idx: int) -> NumbersDict:
-    """
-    Returns sequence length for all data/target keys.
-    """
-    data = self[seq_idx]
-    d = {k: v.size for k, v in data.items()}
-    for update_key in ["data", "target_signals"]:
-      if update_key in d.keys() and "seq_len" in data:
-        d[update_key] = int(data["seq_len"])
-    return NumbersDict(d)
-
-  def update_buffer(self, seq_idx: int, pop_seqs: bool = True):
-    """
-    :param int seq_idx:
-    :param bool pop_seqs: if True, pop sequences from buffer that are outside buffer range
-    """
-    if not self._use_buffer:
-      return
-
-    # debugging information
-    keys = list(self._buffer.keys()) or [0]
-    if not (min(keys) <= seq_idx <= max(keys)):
-      print(f"WARNING: seq_idx {seq_idx} outside range of keys: {self._buffer.keys()}")
-
-    # add sequences
-    for idx in range(seq_idx, min(seq_idx + self._buffer_size // 2, len(self))):
-      if idx not in self._buffer and idx < len(self):
-        try:
-          self._buffer[idx] = next(self._ds_iterator)
-        except StopIteration:
-          print(f"StopIteration for seq_idx {seq_idx}")
-          print(f"Dataset: {self} with SMS-WSJ {self._ds} of len {len(self)}")
-          print(f"Indices in buffer: {self._buffer.keys()}")
-          # raise
-          print(f"WARNING: Ignoring this, reset iterator and continue")
-          self._ds_iterator = iter(self._ds)
-          self._buffer[idx] = next(self._ds_iterator)
-      if idx == len(self) - 1 and 0 not in self._buffer:
-        print(f"Reached end of dataset, reset iterator")
-        try:
-          next(self._ds_iterator)
-        except StopIteration:
-          pass
-        else:
-          print(
-            "WARNING: reached final index of dataset, but iterator has more sequences. "
-            "Maybe the training was restarted from an epoch > 1?")
-        print(f"Current buffer indices: {self._buffer.keys()}")
+        self._ds = ds
         self._ds_iterator = iter(self._ds)
-        for idx_ in range(self._buffer_size // 2):
-          if idx_ not in self._buffer and idx_ < len(self):
-            self._buffer[idx_] = next(self._ds_iterator)
-        print(f"After adding start of dataset to buffer indices: {self._buffer.keys()}")
 
-    # remove sequences
-    if pop_seqs:
-      for idx in list(self._buffer):
-        if not (seq_idx - self._buffer_size // 2 <= idx <= seq_idx + self._buffer_size // 2):
-          if max(self._buffer.keys()) == len(self) - 1 and idx < self._buffer_size // 2:
-            # newly added sequences starting from 0
-            continue
-          self._buffer.pop(idx)
+        self._use_buffer = buffer
+        if self._use_buffer:
+            self._ds = self._ds.prefetch(4, 8).copy(freeze=True)
+        self._buffer = {}  # type Dict[int,[Dict[str,np.array]]]
+        self._buffer_size = 40
 
-  @staticmethod
-  def _cache_zipped_audio(zip_cache: str, json_path: str, dataset_name: str):
-    """
-    Caches and unzips a given archive with SMS-WSJ data which will then be used as data dir.
-    This is done because caching of the single files takes extremely long.
-    """
-    print(f"Cache and unzip SMS-WSJ data from {zip_cache}")
+    def __len__(self) -> int:
+        return len(self._ds)
 
-    # cache and unzip
-    try:
-      zip_cache_cached = sp.check_output(["cf", zip_cache]).strip().decode("utf8")
-      assert zip_cache_cached != zip_cache, "cached and original file have the same path"
-      local_unzipped_dir = os.path.dirname(zip_cache_cached)
-      sp.check_call(["unzip", "-q", "-n", zip_cache_cached, "-d", local_unzipped_dir])
-    except sp.CalledProcessError:
-      print(f"Cache manager: Error occurred when caching and unzipping {zip_cache}")
-      raise
+    def __getitem__(self, seq_idx: int) -> Dict[str, np.array]:
+        return self._get_seq_by_idx(seq_idx)
 
-    # modify json and check if all data is available
-    with open(json_path, "r") as f:
-      json_dict = json.loads(f.read())
-    original_dir = next(iter(json_dict["datasets"][dataset_name].values()))["audio_path"]["original_source"][0]
-    while not original_dir.endswith(os.path.basename(local_unzipped_dir)) and len(original_dir) > 1:
-      original_dir = os.path.dirname(original_dir)
-    for seq in json_dict["datasets"][dataset_name]:
-      for audio_key in ["original_source", "rir"]:
-        for seq_idx in range(len(json_dict["datasets"][dataset_name][seq]["audio_path"][audio_key])):
-          path = json_dict["datasets"][dataset_name][seq]["audio_path"][audio_key][seq_idx]
-          path = path.replace(original_dir, local_unzipped_dir)
-          json_dict["datasets"][dataset_name][seq]["audio_path"][audio_key][seq_idx] = path
-          assert path.startswith(local_unzipped_dir), (
-            f"Audio file {path} was expected to start with {local_unzipped_dir}")
-          assert os.path.exists(path), f"Audio file {path} does not exist"
+    def _get_seq_by_idx(self, seq_idx: int) -> Dict[str, np.array]:
+        """
+        Returns data for sequence index.
+        """
+        if self._use_buffer:
+            assert (
+                seq_idx in self._buffer
+            ), f"seq_idx {seq_idx} not in buffer. Available keys are {self._buffer.keys()}"
+            return self._buffer[seq_idx]
+        else:
+            return self._ds[seq_idx]
 
-    json_path = os.path.join(local_unzipped_dir, "sms_wsj.json")
-    with open(json_path, "w", encoding="utf-8") as f:
-      json.dump(json_dict, f, ensure_ascii=False, indent=4)
+    def get_seq_tag(self, seq_idx: int) -> str:
+        """
+        Returns tag for the sequence of the given index, default is 'seq-{seq_idx}'.
+        """
+        if "seq_tag" in self._get_seq_by_idx(seq_idx):
+            return str(self._get_seq_by_idx(seq_idx)["seq_tag"])
+        else:
+            return "seq-%i" % seq_idx
 
-    print(f"Finished preparation of zip cache data, use json in {json_path}")
+    def get_seq_len(self, seq_idx: int) -> int:
+        """
+        Returns length of the sequence of the given index
+        """
+        if "seq_len" in self._get_seq_by_idx(seq_idx):
+            return int(self._get_seq_by_idx(seq_idx)["seq_len"])
+        else:
+            raise OptionalNotImplementedError
+
+    def get_seq_length_for_keys(self, seq_idx: int) -> NumbersDict:
+        """
+        Returns sequence length for all data/target keys.
+        """
+        data = self[seq_idx]
+        d = {k: v.size for k, v in data.items()}
+        for update_key in ["data", "target_signals"]:
+            if update_key in d.keys() and "seq_len" in data:
+                d[update_key] = int(data["seq_len"])
+        return NumbersDict(d)
+
+    def update_buffer(self, seq_idx: int, pop_seqs: bool = True):
+        """
+        :param int seq_idx:
+        :param bool pop_seqs: if True, pop sequences from buffer that are outside buffer range
+        """
+        if not self._use_buffer:
+            return
+
+        # debugging information
+        keys = list(self._buffer.keys()) or [0]
+        if not (min(keys) <= seq_idx <= max(keys)):
+            print(
+                f"WARNING: seq_idx {seq_idx} outside range of keys: {self._buffer.keys()}"
+            )
+
+        # add sequences
+        for idx in range(seq_idx, min(seq_idx + self._buffer_size // 2, len(self))):
+            if idx not in self._buffer and idx < len(self):
+                try:
+                    self._buffer[idx] = next(self._ds_iterator)
+                except StopIteration:
+                    print(f"StopIteration for seq_idx {seq_idx}")
+                    print(f"Dataset: {self} with SMS-WSJ {self._ds} of len {len(self)}")
+                    print(f"Indices in buffer: {self._buffer.keys()}")
+                    # raise
+                    print(f"WARNING: Ignoring this, reset iterator and continue")
+                    self._ds_iterator = iter(self._ds)
+                    self._buffer[idx] = next(self._ds_iterator)
+            if idx == len(self) - 1 and 0 not in self._buffer:
+                print(f"Reached end of dataset, reset iterator")
+                try:
+                    next(self._ds_iterator)
+                except StopIteration:
+                    pass
+                else:
+                    print(
+                        "WARNING: reached final index of dataset, but iterator has more sequences. "
+                        "Maybe the training was restarted from an epoch > 1?"
+                    )
+                print(f"Current buffer indices: {self._buffer.keys()}")
+                self._ds_iterator = iter(self._ds)
+                for idx_ in range(self._buffer_size // 2):
+                    if idx_ not in self._buffer and idx_ < len(self):
+                        self._buffer[idx_] = next(self._ds_iterator)
+                print(
+                    f"After adding start of dataset to buffer indices: {self._buffer.keys()}"
+                )
+
+        # remove sequences
+        if pop_seqs:
+            for idx in list(self._buffer):
+                if not (
+                    seq_idx - self._buffer_size // 2
+                    <= idx
+                    <= seq_idx + self._buffer_size // 2
+                ):
+                    if (
+                        max(self._buffer.keys()) == len(self) - 1
+                        and idx < self._buffer_size // 2
+                    ):
+                        # newly added sequences starting from 0
+                        continue
+                    self._buffer.pop(idx)
+
+    @staticmethod
+    def _cache_zipped_audio(zip_cache: str, json_path: str, dataset_name: str):
+        """
+        Caches and unzips a given archive with SMS-WSJ data which will then be used as data dir.
+        This is done because caching of the single files takes extremely long.
+        """
+        print(f"Cache and unzip SMS-WSJ data from {zip_cache}")
+
+        # cache and unzip
+        try:
+            zip_cache_cached = sp.check_output(["cf", zip_cache]).strip().decode("utf8")
+            assert (
+                zip_cache_cached != zip_cache
+            ), "cached and original file have the same path"
+            local_unzipped_dir = os.path.dirname(zip_cache_cached)
+            sp.check_call(
+                ["unzip", "-q", "-n", zip_cache_cached, "-d", local_unzipped_dir]
+            )
+        except sp.CalledProcessError:
+            print(
+                f"Cache manager: Error occurred when caching and unzipping {zip_cache}"
+            )
+            raise
+
+        # modify json and check if all data is available
+        with open(json_path, "r") as f:
+            json_dict = json.loads(f.read())
+        original_dir = next(iter(json_dict["datasets"][dataset_name].values()))[
+            "audio_path"
+        ]["original_source"][0]
+        while (
+            not original_dir.endswith(os.path.basename(local_unzipped_dir))
+            and len(original_dir) > 1
+        ):
+            original_dir = os.path.dirname(original_dir)
+        for seq in json_dict["datasets"][dataset_name]:
+            for audio_key in ["original_source", "rir"]:
+                for seq_idx in range(
+                    len(
+                        json_dict["datasets"][dataset_name][seq]["audio_path"][
+                            audio_key
+                        ]
+                    )
+                ):
+                    path = json_dict["datasets"][dataset_name][seq]["audio_path"][
+                        audio_key
+                    ][seq_idx]
+                    path = path.replace(original_dir, local_unzipped_dir)
+                    json_dict["datasets"][dataset_name][seq]["audio_path"][audio_key][
+                        seq_idx
+                    ] = path
+                    assert path.startswith(
+                        local_unzipped_dir
+                    ), f"Audio file {path} was expected to start with {local_unzipped_dir}"
+                    assert os.path.exists(path), f"Audio file {path} does not exist"
+
+        json_path = os.path.join(local_unzipped_dir, "sms_wsj.json")
+        with open(json_path, "w", encoding="utf-8") as f:
+            json.dump(json_dict, f, ensure_ascii=False, indent=4)
+
+        print(f"Finished preparation of zip cache data, use json in {json_path}")
 
 
 class SmsWsjBaseWithRasrClasses(SmsWsjBase):
-  """
-  Base class to wrap the SMS-WSJ dataset and combine it with RASR alignments in an hdf dataset.
-  """
-
-  def __init__(
-      self, rasr_classes_hdf=None, rasr_corpus=None, rasr_segment_prefix="", rasr_segment_postfix="", **kwargs
-  ):
     """
-    :param Optional[str] rasr_classes_hdf: hdf file with dumped RASR class labels
-    :param Optional[str] rasr_corpus: RASR corpus file for reading segment start and end times for padding
-    :param str rasr_segment_prefix: prefix to map SMS-WSJ segment name to RASR segment name
-    :param str rasr_segment_postfix: postfix to map SMS-WSJ segment name to RASR segment name
-    :param kwargs:
+    Base class to wrap the SMS-WSJ dataset and combine it with RASR alignments in an hdf dataset.
     """
-    super(SmsWsjBaseWithRasrClasses, self).__init__(**kwargs)
 
-    # self.data_types = {"target_signals": {"dim": 2, "shape": (None, 2)}}
-    self._rasr_classes_hdf = None
-    if rasr_classes_hdf is not None:
-      self._rasr_classes_hdf = HDFDataset([rasr_classes_hdf], use_cache_manager=True)
-      # self.data_types["target_rasr"] = {"sparse": True, "dim": 9001, "shape": (None, 2)}
-    self._rasr_segment_start_end = {}  # type: Dict[str, Tuple[float, float]]
-    if rasr_corpus is not None:
-      from i6_core.lib.corpus import Corpus
-      corpus = Corpus()
-      corpus.load(rasr_corpus)
-      for seg in corpus.segments():
-        self._rasr_segment_start_end[seg.fullname()] = (seg.start, seg.end)
-    self.rasr_segment_prefix = rasr_segment_prefix
-    self.rasr_segment_postfix = rasr_segment_postfix
+    def __init__(
+        self,
+        rasr_classes_hdf=None,
+        rasr_corpus=None,
+        rasr_segment_prefix="",
+        rasr_segment_postfix="",
+        **kwargs,
+    ):
+        """
+        :param Optional[str] rasr_classes_hdf: hdf file with dumped RASR class labels
+        :param Optional[str] rasr_corpus: RASR corpus file for reading segment start and end times for padding
+        :param str rasr_segment_prefix: prefix to map SMS-WSJ segment name to RASR segment name
+        :param str rasr_segment_postfix: postfix to map SMS-WSJ segment name to RASR segment name
+        :param kwargs:
+        """
+        super(SmsWsjBaseWithRasrClasses, self).__init__(**kwargs)
 
-  def __getitem__(self, seq_idx: int) -> Dict[str, np.array]:
-    d = self._get_seq_by_idx(seq_idx)
-    if self._rasr_classes_hdf is not None:
-      rasr_seq_tags = [
-        f"{self.rasr_segment_prefix}{d['seq_tag']}_{speaker}{self.rasr_segment_postfix}"
-        for speaker in range(d["target_signals"].shape[1])]
-      rasr_targets = []
-      for idx, rasr_seq_tag in enumerate(rasr_seq_tags):
-        rasr_targets.append(self._rasr_classes_hdf.get_data_by_seq_tag(rasr_seq_tag, "classes"))
-      start_end_times = [self._rasr_segment_start_end.get(rasr_seq_tag, (0, 0)) for rasr_seq_tag in rasr_seq_tags]
-      padded_len_sec = max(start_end[1] for start_end in start_end_times)
-      padded_len_frames = max(rasr_target.shape[0] for rasr_target in rasr_targets)
-      for speaker_idx in range(len(rasr_targets)):
-        pad_start = 0
-        if padded_len_sec > 0:
-          pad_start = round(start_end_times[speaker_idx][0] / padded_len_sec * padded_len_frames)
-        pad_end = padded_len_frames - rasr_targets[speaker_idx].shape[0] - pad_start
-        if pad_end < 0:
-          pad_start += pad_end
-          assert pad_start >= 0
-          pad_end = 0
-        rasr_targets[speaker_idx] = np.concatenate([
-          9000 * np.ones(pad_start), rasr_targets[speaker_idx], 9000 * np.ones(pad_end)])
-      d["target_rasr"] = np.stack(rasr_targets).T
-      d["target_rasr_len"] = np.array(padded_len_frames)
-    return d
+        # self.data_types = {"target_signals": {"dim": 2, "shape": (None, 2)}}
+        self._rasr_classes_hdf = None
+        if rasr_classes_hdf is not None:
+            self._rasr_classes_hdf = HDFDataset(
+                [rasr_classes_hdf], use_cache_manager=True
+            )
+            # self.data_types["target_rasr"] = {"sparse": True, "dim": 9001, "shape": (None, 2)}
+        self._rasr_segment_start_end = {}  # type: Dict[str, Tuple[float, float]]
+        if rasr_corpus is not None:
+            from i6_core.lib.corpus import Corpus
 
-  def get_seq_length_for_keys(self, seq_idx: int) -> NumbersDict:
-    """
-    Returns sequence length for all data/target keys.
-    """
-    d = super(SmsWsjBaseWithRasrClasses, self).get_seq_length_for_keys(seq_idx)
-    data = self[seq_idx]
-    d["target_rasr"] = int(data["target_rasr_len"])
-    return NumbersDict(d)
+            corpus = Corpus()
+            corpus.load(rasr_corpus)
+            for seg in corpus.segments():
+                self._rasr_segment_start_end[seg.fullname()] = (seg.start, seg.end)
+        self.rasr_segment_prefix = rasr_segment_prefix
+        self.rasr_segment_postfix = rasr_segment_postfix
+
+    def __getitem__(self, seq_idx: int) -> Dict[str, np.array]:
+        d = self._get_seq_by_idx(seq_idx)
+        if self._rasr_classes_hdf is not None:
+            rasr_seq_tags = [
+                f"{self.rasr_segment_prefix}{d['seq_tag']}_{speaker}{self.rasr_segment_postfix}"
+                for speaker in range(d["target_signals"].shape[1])
+            ]
+            rasr_targets = []
+            for idx, rasr_seq_tag in enumerate(rasr_seq_tags):
+                rasr_targets.append(
+                    self._rasr_classes_hdf.get_data_by_seq_tag(rasr_seq_tag, "classes")
+                )
+            start_end_times = [
+                self._rasr_segment_start_end.get(rasr_seq_tag, (0, 0))
+                for rasr_seq_tag in rasr_seq_tags
+            ]
+            padded_len_sec = max(start_end[1] for start_end in start_end_times)
+            padded_len_frames = max(
+                rasr_target.shape[0] for rasr_target in rasr_targets
+            )
+            for speaker_idx in range(len(rasr_targets)):
+                pad_start = 0
+                if padded_len_sec > 0:
+                    pad_start = round(
+                        start_end_times[speaker_idx][0]
+                        / padded_len_sec
+                        * padded_len_frames
+                    )
+                pad_end = (
+                    padded_len_frames - rasr_targets[speaker_idx].shape[0] - pad_start
+                )
+                if pad_end < 0:
+                    pad_start += pad_end
+                    assert pad_start >= 0
+                    pad_end = 0
+                rasr_targets[speaker_idx] = np.concatenate(
+                    [
+                        9000 * np.ones(pad_start),
+                        rasr_targets[speaker_idx],
+                        9000 * np.ones(pad_end),
+                    ]
+                )
+            d["target_rasr"] = np.stack(rasr_targets).T
+            d["target_rasr_len"] = np.array(padded_len_frames)
+        return d
+
+    def get_seq_length_for_keys(self, seq_idx: int) -> NumbersDict:
+        """
+        Returns sequence length for all data/target keys.
+        """
+        d = super(SmsWsjBaseWithRasrClasses, self).get_seq_length_for_keys(seq_idx)
+        data = self[seq_idx]
+        d["target_rasr"] = int(data["target_rasr_len"])
+        return NumbersDict(d)
 
 
 class SmsWsjWrapper(MapDatasetWrapper):
-  """
-  Base class for datasets that can be used in RETURNN config.
-  """
+    """
+    Base class for datasets that can be used in RETURNN config.
+    """
 
-  def __init__(
-      self, sms_wsj_base, **kwargs
-  ):
-    """
-    :param Optional[SmsWsjBase] sms_wsj_base: SMS-WSJ base class to allow inherited classes to modify this
-    """
-    if "seq_ordering" not in kwargs:
-      print("Warning: no shuffling is enabled by default", file=log.v)
-    super(SmsWsjWrapper, self).__init__(sms_wsj_base, **kwargs)
-    # self.num_outputs = ...  # needs to be set in derived classes
+    def __init__(self, sms_wsj_base, **kwargs):
+        """
+        :param Optional[SmsWsjBase] sms_wsj_base: SMS-WSJ base class to allow inherited classes to modify this
+        """
+        if "seq_ordering" not in kwargs:
+            print("Warning: no shuffling is enabled by default", file=log.v)
+        super(SmsWsjWrapper, self).__init__(sms_wsj_base, **kwargs)
+        # self.num_outputs = ...  # needs to be set in derived classes
 
-    def _get_seq_length(seq_idx: int) -> NumbersDict:
-      """
-      Returns sequence length for all data/target keys.
-      """
-      corpus_seq_idx = self.get_corpus_seq_idx(seq_idx)
-      return sms_wsj_base.get_seq_length_for_keys(corpus_seq_idx)
+        def _get_seq_length(seq_idx: int) -> NumbersDict:
+            """
+            Returns sequence length for all data/target keys.
+            """
+            corpus_seq_idx = self.get_corpus_seq_idx(seq_idx)
+            return sms_wsj_base.get_seq_length_for_keys(corpus_seq_idx)
 
-    self.get_seq_length = _get_seq_length
+        self.get_seq_length = _get_seq_length
 
-  @staticmethod
-  def _pre_batch_transform(inputs: Dict[str, Any]) -> Dict[str, np.array]:
-    """
-    Used to process raw SMS-WSJ data
-    :param  inputs: input as coming from SMS-WSJ
-    """
-    return_dict = {
-      "seq_tag": np.array(inputs["example_id"], dtype=object),
-      "source_id": np.array(inputs["source_id"], dtype=object),
-      "seq_len": np.array(inputs["num_samples"]["observation"]),
-    }
-    return return_dict
+    @staticmethod
+    def _pre_batch_transform(inputs: Dict[str, Any]) -> Dict[str, np.array]:
+        """
+        Used to process raw SMS-WSJ data
+        :param  inputs: input as coming from SMS-WSJ
+        """
+        return_dict = {
+            "seq_tag": np.array(inputs["example_id"], dtype=object),
+            "source_id": np.array(inputs["source_id"], dtype=object),
+            "seq_len": np.array(inputs["num_samples"]["observation"]),
+        }
+        return return_dict
 
-  def _collect_single_seq(self, seq_idx: int) -> DatasetSeq:
-    """
-    :param seq_idx: sorted seq idx
-    """
-    corpus_seq_idx = self.get_corpus_seq_idx(seq_idx)
-    self._dataset.update_buffer(corpus_seq_idx)
-    data = self._dataset[corpus_seq_idx]
-    assert "seq_tag" in data
-    return DatasetSeq(seq_idx, features=data, seq_tag=data["seq_tag"])
+    def _collect_single_seq(self, seq_idx: int) -> DatasetSeq:
+        """
+        :param seq_idx: sorted seq idx
+        """
+        corpus_seq_idx = self.get_corpus_seq_idx(seq_idx)
+        self._dataset.update_buffer(corpus_seq_idx)
+        data = self._dataset[corpus_seq_idx]
+        assert "seq_tag" in data
+        return DatasetSeq(seq_idx, features=data, seq_tag=data["seq_tag"])
 
-  def init_seq_order(self, epoch: Optional[int] = None, **kwargs) -> bool:
-    """
-    Override this in order to update the buffer. get_seq_length is often called before _collect_single_seq, therefore
-    the buffer does not contain the initial indices when continuing the training from an epoch > 0.
-    """
-    out = super(SmsWsjWrapper, self).init_seq_order(epoch=epoch, **kwargs)
-    buffer_index = ((epoch or 1) - 1) * self.num_seqs % len(self._dataset)
-    self._dataset.update_buffer(buffer_index, pop_seqs=False)
-    return out
+    def init_seq_order(self, epoch: Optional[int] = None, **kwargs) -> bool:
+        """
+        Override this in order to update the buffer. get_seq_length is often called before _collect_single_seq, therefore
+        the buffer does not contain the initial indices when continuing the training from an epoch > 0.
+        """
+        out = super(SmsWsjWrapper, self).init_seq_order(epoch=epoch, **kwargs)
+        buffer_index = ((epoch or 1) - 1) * self.num_seqs % len(self._dataset)
+        self._dataset.update_buffer(buffer_index, pop_seqs=False)
+        return out
 
 
 class SmsWsjMixtureEarlyDataset(SmsWsjWrapper):
-  """
-  Dataset with audio mixture and early signals as target.
-  """
+    """
+    Dataset with audio mixture and early signals as target.
+    """
 
-  def __init__(
-      self, dataset_name, json_path, num_outputs=None, zip_cache=None, sms_wsj_base=None, **kwargs
-  ):
-    """
-    :param str dataset_name: "train_si284", "cv_dev93" or "test_eval92"
-    :param str json_path: path to SMS-WSJ json file
-    :param Optional[Dict[str, List[int]]] num_outputs: num_outputs for RETURNN dataset
-    :param Optional[str] zip_cache: zip archive with SMS-WSJ data which can be cached, unzipped and used as data dir
-    :param Optional[SmsWsjBase] sms_wsj_base: SMS-WSJ base class to allow inherited classes to modify this
-    """
-    if sms_wsj_base is None:
-      sms_wsj_base = SmsWsjBase(
-        dataset_name=dataset_name,
-        json_path=json_path,
-        pre_batch_transform=self._pre_batch_transform,
-        scenario_map_args={"add_speech_reverberation_early": True},
-        zip_cache=zip_cache)
-    super(SmsWsjMixtureEarlyDataset, self).__init__(sms_wsj_base, **kwargs)
-    # typically data is raw waveform so 1-D and dense, target signals are 2-D (one for each speaker) and dense
-    self.num_outputs = num_outputs or {"data": [1, 2], "target_signals": [2, 2]}
+    def __init__(
+        self,
+        dataset_name,
+        json_path,
+        num_outputs=None,
+        zip_cache=None,
+        sms_wsj_base=None,
+        **kwargs,
+    ):
+        """
+        :param str dataset_name: "train_si284", "cv_dev93" or "test_eval92"
+        :param str json_path: path to SMS-WSJ json file
+        :param Optional[Dict[str, List[int]]] num_outputs: num_outputs for RETURNN dataset
+        :param Optional[str] zip_cache: zip archive with SMS-WSJ data which can be cached, unzipped and used as data dir
+        :param Optional[SmsWsjBase] sms_wsj_base: SMS-WSJ base class to allow inherited classes to modify this
+        """
+        if sms_wsj_base is None:
+            sms_wsj_base = SmsWsjBase(
+                dataset_name=dataset_name,
+                json_path=json_path,
+                pre_batch_transform=self._pre_batch_transform,
+                scenario_map_args={"add_speech_reverberation_early": True},
+                zip_cache=zip_cache,
+            )
+        super(SmsWsjMixtureEarlyDataset, self).__init__(sms_wsj_base, **kwargs)
+        # typically data is raw waveform so 1-D and dense, target signals are 2-D (one for each speaker) and dense
+        self.num_outputs = num_outputs or {"data": [1, 2], "target_signals": [2, 2]}
 
-  @staticmethod
-  def _pre_batch_transform(inputs: Dict[str, Any]) -> Dict[str, np.array]:
-    """
-    Used to process raw SMS-WSJ data
-    :param inputs: input as coming from SMS-WSJ
-    """
-    return_dict = SmsWsjWrapper._pre_batch_transform(inputs)
-    return_dict.update({
-      "data": inputs["audio_data"]["observation"][:1, :].T,  # take first of 6 channels: (T, 1)
-      "target_signals": inputs["audio_data"]["speech_reverberation_early"][:, 0, :].T,  # first of 6 channels: (T, S)
-    })
-    return return_dict
+    @staticmethod
+    def _pre_batch_transform(inputs: Dict[str, Any]) -> Dict[str, np.array]:
+        """
+        Used to process raw SMS-WSJ data
+        :param inputs: input as coming from SMS-WSJ
+        """
+        return_dict = SmsWsjWrapper._pre_batch_transform(inputs)
+        return_dict.update(
+            {
+                "data": inputs["audio_data"]["observation"][
+                    :1, :
+                ].T,  # take first of 6 channels: (T, 1)
+                "target_signals": inputs["audio_data"]["speech_reverberation_early"][
+                    :, 0, :
+                ].T,  # first of 6 channels: (T, S)
+            }
+        )
+        return return_dict
 
 
 class SmsWsjMixtureEarlyAlignmentDataset(SmsWsjMixtureEarlyDataset):
-  """
-  Dataset with audio mixture, target early signals and target RASR alignments.
-  """
+    """
+    Dataset with audio mixture, target early signals and target RASR alignments.
+    """
 
-  def __init__(
-      self, dataset_name, json_path, num_outputs=None, rasr_num_outputs=None, rasr_segment_prefix="",
-      rasr_segment_postfix="", rasr_classes_hdf=None, rasr_corpus=None, zip_cache=None, **kwargs
-  ):
-    """
-    :param str dataset_name: "train_si284", "cv_dev93" or "test_eval92"
-    :param str json_path: path to SMS-WSJ json file
-    :param Optional[Dict[str, List[int]]] num_outputs: num_outputs for RETURNN dataset
-    :param Optional[int] rasr_num_outputs: number of output labels for RASR alignment, e.g. 9001 for that CART size
-    :param str rasr_segment_prefix: prefix to map SMS-WSJ segment name to RASR segment name
-    :param str rasr_segment_postfix: postfix to map SMS-WSJ segment name to RASR segment name
-    :param str rasr_classes_hdf: hdf file with dumped RASR class labels
-    :param str rasr_corpus: RASR corpus file for reading segment start and end times for padding
-    :param Optional[str] zip_cache: zip archive with SMS-WSJ data which can be cached, unzipped and used as data dir
-    """
-    sms_wsj_base = SmsWsjBaseWithRasrClasses(
-      dataset_name=dataset_name,
-      json_path=json_path,
-      pre_batch_transform=self._pre_batch_transform,
-      scenario_map_args={"add_speech_reverberation_early": True},
-      rasr_classes_hdf=rasr_classes_hdf,
-      rasr_corpus=rasr_corpus,
-      rasr_segment_prefix=rasr_segment_prefix,
-      rasr_segment_postfix=rasr_segment_postfix,
-      zip_cache=zip_cache)
-    super(SmsWsjMixtureEarlyAlignmentDataset, self).__init__(
-      dataset_name, json_path, num_outputs=num_outputs, zip_cache=zip_cache, sms_wsj_base=sms_wsj_base, **kwargs)
-    if num_outputs is not None:
-      self.num_outputs = num_outputs
-    else:
-      assert rasr_num_outputs is not None, "either num_outputs or rasr_num_outputs has to be given"
-      self.num_outputs["target_rasr"] = [rasr_num_outputs, 1]  # target alignments are sparse with the given dim
+    def __init__(
+        self,
+        dataset_name,
+        json_path,
+        num_outputs=None,
+        rasr_num_outputs=None,
+        rasr_segment_prefix="",
+        rasr_segment_postfix="",
+        rasr_classes_hdf=None,
+        rasr_corpus=None,
+        zip_cache=None,
+        **kwargs,
+    ):
+        """
+        :param str dataset_name: "train_si284", "cv_dev93" or "test_eval92"
+        :param str json_path: path to SMS-WSJ json file
+        :param Optional[Dict[str, List[int]]] num_outputs: num_outputs for RETURNN dataset
+        :param Optional[int] rasr_num_outputs: number of output labels for RASR alignment, e.g. 9001 for that CART size
+        :param str rasr_segment_prefix: prefix to map SMS-WSJ segment name to RASR segment name
+        :param str rasr_segment_postfix: postfix to map SMS-WSJ segment name to RASR segment name
+        :param str rasr_classes_hdf: hdf file with dumped RASR class labels
+        :param str rasr_corpus: RASR corpus file for reading segment start and end times for padding
+        :param Optional[str] zip_cache: zip archive with SMS-WSJ data which can be cached, unzipped and used as data dir
+        """
+        sms_wsj_base = SmsWsjBaseWithRasrClasses(
+            dataset_name=dataset_name,
+            json_path=json_path,
+            pre_batch_transform=self._pre_batch_transform,
+            scenario_map_args={"add_speech_reverberation_early": True},
+            rasr_classes_hdf=rasr_classes_hdf,
+            rasr_corpus=rasr_corpus,
+            rasr_segment_prefix=rasr_segment_prefix,
+            rasr_segment_postfix=rasr_segment_postfix,
+            zip_cache=zip_cache,
+        )
+        super(SmsWsjMixtureEarlyAlignmentDataset, self).__init__(
+            dataset_name,
+            json_path,
+            num_outputs=num_outputs,
+            zip_cache=zip_cache,
+            sms_wsj_base=sms_wsj_base,
+            **kwargs,
+        )
+        if num_outputs is not None:
+            self.num_outputs = num_outputs
+        else:
+            assert (
+                rasr_num_outputs is not None
+            ), "either num_outputs or rasr_num_outputs has to be given"
+            self.num_outputs["target_rasr"] = [
+                rasr_num_outputs,
+                1,
+            ]  # target alignments are sparse with the given dim

--- a/common/datasets/sms_wsj/returnn_datasets.py
+++ b/common/datasets/sms_wsj/returnn_datasets.py
@@ -487,7 +487,7 @@ class SmsWsjMixtureEarlyAlignmentDataset(SmsWsjMixtureEarlyDataset):
             pad_label=pad_label,
             hdf_data_key=hdf_data_key,
         )
-        super(SmsWsjMixtureEarlyAlignmentDataset, self).__init__(
+        super().__init__(
             dataset_name,
             json_path,
             num_outputs=num_outputs,

--- a/common/datasets/sms_wsj/returnn_datasets.py
+++ b/common/datasets/sms_wsj/returnn_datasets.py
@@ -316,7 +316,7 @@ class SmsWsjBaseWithHdfClasses(SmsWsjBase):
             total_pad_frames = padded_len - rasr_target.shape[0]
             if total_pad_frames == 0:
                 continue
-            pad_start = round(d["offset"][speaker_idx] / d["seq_len"] * padded_len)
+            pad_start = int(round(d["offset"][speaker_idx] / d["seq_len"] * padded_len))
             pad_start = min(pad_start, total_pad_frames)
             pad_end = total_pad_frames - pad_start
             if pad_start or pad_end:

--- a/common/datasets/sms_wsj/returnn_datasets.py
+++ b/common/datasets/sms_wsj/returnn_datasets.py
@@ -291,7 +291,7 @@ class SmsWsjBaseWithRasrClasses(SmsWsjBase):
 
     def __getitem__(self, seq_idx: int) -> Dict[str, np.array]:
         d = self._get_seq_by_idx(seq_idx)
-        rasr_seq_tags = self._segment_to_rasr(d["seq_tag"])
+        rasr_seq_tags = self._segment_to_rasr(str(d["seq_tag"]))
         assert (
             len(rasr_seq_tags) == d["target_signals"].shape[1]
         ), f"got {len(rasr_seq_tags)} segment names, but there are {d['target_signals'].shape[1]} target signals"

--- a/common/datasets/sms_wsj/returnn_datasets.py
+++ b/common/datasets/sms_wsj/returnn_datasets.py
@@ -84,7 +84,9 @@ class ZipAudioReader(AudioReader):
                 data = None
                 for _ in range(5):
                     try:
-                        data, sample_rate = soundfile.read(io.BytesIO(self._zip.read(file_zip)))
+                        data, sample_rate = soundfile.read(
+                            io.BytesIO(self._zip.read(file_zip))
+                        )
                     except:
                         print(
                             f"data could not be read: {file_zip} from {self._zip.filename}, retry...",
@@ -92,7 +94,9 @@ class ZipAudioReader(AudioReader):
                         )
                     else:
                         break
-                assert data is not None, f"data could not be read: {file_zip} from {self._zip.filename}, abort now"
+                assert (
+                    data is not None
+                ), f"data could not be read: {file_zip} from {self._zip.filename}, abort now"
             else:
                 data, sample_rate = soundfile.read(file)
             return data.T

--- a/common/datasets/sms_wsj/returnn_datasets.py
+++ b/common/datasets/sms_wsj/returnn_datasets.py
@@ -76,7 +76,7 @@ class SmsWsjBase(MapDatasetBase):
             **(scenario_map_args or {}),
         }
         ds = ds.map(functools.partial(scenario_map_fn, **scenario_map_args))
-        ds = ds.map(functools.partial(pre_batch_transform))
+        ds = ds.map(pre_batch_transform)
 
         self._ds = ds
         self._ds_iterator = iter(self._ds)

--- a/common/datasets/sms_wsj/returnn_datasets.py
+++ b/common/datasets/sms_wsj/returnn_datasets.py
@@ -566,14 +566,13 @@ class SmsWsjMixtureEarlyBpeDataset(SmsWsjMixtureEarlyDataset):
             **kwargs,
         )
         from returnn.datasets.util.vocabulary import BytePairEncoding
+
         self.bpe = BytePairEncoding(**bpe)
         self.text_proc = text_proc or (lambda x: x)
         if num_outputs is not None:
             self.num_outputs = num_outputs
         else:
-            assert (
-                bpe is not None
-            ), "either num_outputs or bpe has to be given"
+            assert bpe is not None, "either num_outputs or bpe has to be given"
             self.num_outputs["target_bpe"] = [
                 self.bpe.num_labels,
                 1,
@@ -586,6 +585,10 @@ class SmsWsjMixtureEarlyBpeDataset(SmsWsjMixtureEarlyDataset):
         """
         return_dict = SmsWsjMixtureEarlyDataset._pre_batch_transform(inputs)
         for speaker, orth in enumerate(inputs["kaldi_transcription"]):
-            return_dict[f"target_bpe_{speaker}"] = np.array(self.bpe.get_seq(self.text_proc(orth)), dtype="int32")
-            return_dict[f"target_bpe_{speaker}_len"] = np.array(return_dict[f"target_bpe_{speaker}"].size)
+            return_dict[f"target_bpe_{speaker}"] = np.array(
+                self.bpe.get_seq(self.text_proc(orth)), dtype="int32"
+            )
+            return_dict[f"target_bpe_{speaker}_len"] = np.array(
+                return_dict[f"target_bpe_{speaker}"].size
+            )
         return return_dict

--- a/common/datasets/sms_wsj/returnn_datasets.py
+++ b/common/datasets/sms_wsj/returnn_datasets.py
@@ -362,7 +362,7 @@ class SmsWsjWrapper(MapDatasetWrapper):
         therefore the buffer does not contain the initial indices when continuing the training from an epoch > 0.
         """
         out = super().init_seq_order(epoch=epoch, **kwargs)
-        buffer_index = ((epoch or 1) - 1) * self.num_seqs % len(self._dataset)
+        buffer_index = self.get_corpus_seq_idx(0)
         self._dataset.update_buffer(buffer_index)
         return out
 

--- a/common/datasets/sms_wsj/returnn_datasets.py
+++ b/common/datasets/sms_wsj/returnn_datasets.py
@@ -81,7 +81,18 @@ class ZipAudioReader(AudioReader):
             if self._zip is not None:
                 assert file.startswith(self._zip_prefix)
                 file_zip = file[len(self._zip_prefix) :]
-                data, sample_rate = soundfile.read(io.BytesIO(self._zip.read(file_zip)))
+                data = None
+                for _ in range(5):
+                    try:
+                        data, sample_rate = soundfile.read(io.BytesIO(self._zip.read(file_zip)))
+                    except:
+                        print(
+                            f"data could not be read: {file_zip} from {self._zip.filename}, retry...",
+                            file=returnn_log.v4,
+                        )
+                    else:
+                        break
+                assert data is not None, f"data could not be read: {file_zip} from {self._zip.filename}, abort now"
             else:
                 data, sample_rate = soundfile.read(file)
             return data.T

--- a/common/datasets/sms_wsj/returnn_datasets.py
+++ b/common/datasets/sms_wsj/returnn_datasets.py
@@ -52,12 +52,8 @@ class ZipAudioReader(AudioReader):
     """
     Reads the audio data of an example from a zip file.
     """
-    def __init__(
-            self,
-            zip_path=None,
-            zip_prefix="",
-            **kwargs
-    ):
+
+    def __init__(self, zip_path=None, zip_prefix="", **kwargs):
         """
         :param Optional[str] zip_path: zip archive with SMS-WSJ data
         :param str zip_prefix: prefix of filename that needs to be removed for the lookup in the zip archive
@@ -84,7 +80,7 @@ class ZipAudioReader(AudioReader):
         else:
             if self._zip is not None:
                 assert file.startswith(self._zip_prefix)
-                file_zip = file[len(self._zip_prefix):]
+                file_zip = file[len(self._zip_prefix) :]
                 data, sample_rate = soundfile.read(io.BytesIO(self._zip.read(file_zip)))
             else:
                 data, sample_rate = soundfile.read(file)
@@ -139,7 +135,10 @@ class SmsWsjBase(MapDatasetBase):
             ), "cached and original file have the same path"
             json_path = json_path_cached
             audio_reader = ZipAudioReader(
-                zip_path=zip_cache_cached, zip_prefix=zip_prefix, keys=("original_source", "rir"))
+                zip_path=zip_cache_cached,
+                zip_prefix=zip_prefix,
+                keys=("original_source", "rir"),
+            )
         else:
             audio_reader = AudioReader(keys=("original_source", "rir"))
 
@@ -399,7 +398,9 @@ class SmsWsjMixtureEarlyDataset(SmsWsjWrapper):
         :param Optional[Dict[str, List[int]]] num_outputs: num_outputs for RETURNN dataset
         """
         if sms_wsj_base is None:
-            assert sms_wsj_kwargs is not None, "either sms_wsj_base or sms_wsj_kwargs need to be given"
+            assert (
+                sms_wsj_kwargs is not None
+            ), "either sms_wsj_base or sms_wsj_kwargs need to be given"
             sms_wsj_base = SmsWsjBase(
                 pre_batch_transform=self._pre_batch_transform,
                 scenario_map_args={"add_speech_reverberation_early": True},
@@ -458,7 +459,9 @@ class SmsWsjMixtureEarlyAlignmentDataset(SmsWsjMixtureEarlyDataset):
                     "shape": (None, 2),
                 },
             }
-            assert sms_wsj_kwargs is not None, "either sms_wsj_base or sms_wsj_kwargs need to be given"
+            assert (
+                sms_wsj_kwargs is not None
+            ), "either sms_wsj_base or sms_wsj_kwargs need to be given"
             sms_wsj_base = SmsWsjBaseWithHdfClasses(
                 pre_batch_transform=self._pre_batch_transform,
                 scenario_map_args={"add_speech_reverberation_early": True},
@@ -526,7 +529,9 @@ class SmsWsjMixtureEarlyBpeDataset(SmsWsjMixtureEarlyDataset):
                     "shape": (None, 2),
                 },
             }
-            assert sms_wsj_kwargs is not None, "either sms_wsj_base or sms_wsj_kwargs need to be given"
+            assert (
+                sms_wsj_kwargs is not None
+            ), "either sms_wsj_base or sms_wsj_kwargs need to be given"
             sms_wsj_base = SmsWsjBase(
                 pre_batch_transform=self._pre_batch_transform,
                 scenario_map_args={"add_speech_reverberation_early": True},

--- a/common/datasets/sms_wsj/returnn_datasets.py
+++ b/common/datasets/sms_wsj/returnn_datasets.py
@@ -558,7 +558,7 @@ class SmsWsjMixtureEarlyBpeDataset(SmsWsjMixtureEarlyDataset):
             zip_cache=zip_cache,
             data_types=data_types,
         )
-        super(SmsWsjMixtureEarlyBpeDataset, self).__init__(
+        super().__init__(
             dataset_name,
             json_path,
             num_outputs=num_outputs,

--- a/common/datasets/sms_wsj/returnn_datasets.py
+++ b/common/datasets/sms_wsj/returnn_datasets.py
@@ -46,6 +46,8 @@ class SmsWsjBase(MapDatasetBase):
         buffer=True,
         zip_cache=None,
         scenario_map_args=None,
+        prefetch_num_workers=4,
+        prefetch_buffer_size=40,
         **kwargs,
     ):
         """
@@ -83,9 +85,9 @@ class SmsWsjBase(MapDatasetBase):
 
         self._use_buffer = buffer
         if self._use_buffer:
-            self._ds = self._ds.prefetch(4, 8).copy(freeze=True)
+            self._ds = self._ds.prefetch(prefetch_num_workers, prefetch_buffer_size).copy(freeze=True)
         self._buffer = {}  # type Dict[int,[Dict[str,np.array]]]
-        self._buffer_size = 40
+        self._buffer_size = prefetch_buffer_size
 
     def __len__(self) -> int:
         return len(self._ds)
@@ -571,7 +573,6 @@ class SmsWsjMixtureEarlyBpeDataset(SmsWsjMixtureEarlyDataset):
         if num_outputs is not None:
             self.num_outputs = num_outputs
         else:
-            assert bpe is not None, "either num_outputs or bpe has to be given"
             self.num_outputs["target_bpe"] = [
                 self.bpe.num_labels,
                 1,

--- a/common/datasets/sms_wsj/returnn_datasets.py
+++ b/common/datasets/sms_wsj/returnn_datasets.py
@@ -149,17 +149,8 @@ class SmsWsjBase(MapDatasetBase):
 
         # add sequences
         for idx in range(seq_idx, min(seq_idx + self._buffer_size // 2, len(self))):
-            if idx not in self._buffer and idx < len(self):
-                try:
-                    self._buffer[idx] = next(self._ds_iterator)
-                except StopIteration:
-                    print(f"StopIteration for seq_idx {seq_idx}")
-                    print(f"Dataset: {self} with SMS-WSJ {self._ds} of len {len(self)}")
-                    print(f"Indices in buffer: {self._buffer.keys()}")
-                    # raise
-                    print(f"WARNING: Ignoring this, reset iterator and continue")
-                    self._ds_iterator = iter(self._ds)
-                    self._buffer[idx] = next(self._ds_iterator)
+            if idx not in self._buffer:
+                self._buffer[idx] = next(self._ds_iterator)
             if idx == len(self) - 1 and 0 not in self._buffer:
                 print(f"Reached end of dataset, reset iterator")
                 try:
@@ -173,8 +164,8 @@ class SmsWsjBase(MapDatasetBase):
                     )
                 print(f"Current buffer indices: {self._buffer.keys()}")
                 self._ds_iterator = iter(self._ds)
-                for idx_ in range(self._buffer_size // 2):
-                    if idx_ not in self._buffer and idx_ < len(self):
+                for idx_ in range(min(self._buffer_size // 2, len(self))):
+                    if idx_ not in self._buffer:
                         self._buffer[idx_] = next(self._ds_iterator)
                 print(
                     f"After adding start of dataset to buffer indices: {self._buffer.keys()}"

--- a/common/datasets/sms_wsj/returnn_datasets.py
+++ b/common/datasets/sms_wsj/returnn_datasets.py
@@ -85,7 +85,9 @@ class SmsWsjBase(MapDatasetBase):
 
         self._use_buffer = buffer
         if self._use_buffer:
-            self._ds = self._ds.prefetch(prefetch_num_workers, prefetch_buffer_size).copy(freeze=True)
+            self._ds = self._ds.prefetch(
+                prefetch_num_workers, prefetch_buffer_size
+            ).copy(freeze=True)
         self._buffer = {}  # type Dict[int,[Dict[str,np.array]]]
         self._buffer_size = prefetch_buffer_size
 
@@ -121,7 +123,6 @@ class SmsWsjBase(MapDatasetBase):
             return int(self._get_seq_by_idx(seq_idx)["seq_len"])
         except KeyError:
             raise OptionalNotImplementedError
-            
 
     def get_seq_length_for_keys(self, seq_idx: int) -> NumbersDict:
         """

--- a/common/datasets/sms_wsj/returnn_datasets.py
+++ b/common/datasets/sms_wsj/returnn_datasets.py
@@ -56,7 +56,7 @@ class SmsWsjBase(MapDatasetBase):
         # noinspection PyUnresolvedReferences
         from sms_wsj.database import SmsWsj, AudioReader, scenario_map_fn
 
-        super(SmsWsjBase, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         self.data_types = data_types
 
@@ -300,7 +300,7 @@ class SmsWsjBaseWithRasrClasses(SmsWsjBase):
         :param str hdf_data_key: data key under which the alignment is stored in the hdf, usually "classes" or "data"
         :param kwargs:
         """
-        super(SmsWsjBaseWithRasrClasses, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         self._rasr_classes_hdf = HDFDataset([rasr_classes_hdf], use_cache_manager=True)
         self._segment_to_rasr = segment_to_rasr
@@ -342,7 +342,7 @@ class SmsWsjBaseWithRasrClasses(SmsWsjBase):
         """
         Returns sequence length for all data/target keys.
         """
-        d = super(SmsWsjBaseWithRasrClasses, self).get_seq_length_for_keys(seq_idx)
+        d = super().get_seq_length_for_keys(seq_idx)
         data = self[seq_idx]
         d["target_rasr"] = int(data["target_rasr_len"])
         return NumbersDict(d)
@@ -359,7 +359,7 @@ class SmsWsjWrapper(MapDatasetWrapper):
         """
         if "seq_ordering" not in kwargs:
             print("Warning: no shuffling is enabled by default", file=log.v)
-        super(SmsWsjWrapper, self).__init__(sms_wsj_base, **kwargs)
+        super().__init__(sms_wsj_base, **kwargs)
         # self.num_outputs = ...  # needs to be set in derived classes
 
         def _get_seq_length(seq_idx: int) -> NumbersDict:
@@ -399,7 +399,7 @@ class SmsWsjWrapper(MapDatasetWrapper):
         Override this in order to update the buffer. get_seq_length is often called before _collect_single_seq,
         therefore the buffer does not contain the initial indices when continuing the training from an epoch > 0.
         """
-        out = super(SmsWsjWrapper, self).init_seq_order(epoch=epoch, **kwargs)
+        out = super().init_seq_order(epoch=epoch, **kwargs)
         buffer_index = ((epoch or 1) - 1) * self.num_seqs % len(self._dataset)
         self._dataset.update_buffer(buffer_index, pop_seqs=False)
         return out

--- a/common/datasets/sms_wsj/returnn_datasets.py
+++ b/common/datasets/sms_wsj/returnn_datasets.py
@@ -226,9 +226,10 @@ class SmsWsjBase(MapDatasetBase):
         # unzip
         unzip_cmd = ["unzip", "-q", "-n", zip_cache_cached, "-d", local_base_dir]
         print(" ".join(unzip_cmd), file=returnn_log.v4)
-        sp.check_call(unzip_cmd)
+        sp.check_output(unzip_cmd)
         print("Finished unzipping", file=returnn_log.v4)
-        sp.check_call(["chmod", "-R", "-f", "o+w", local_base_dir])
+        # force exit code 0 for the case that the path does not belong to the user so permissions cannot be changed
+        sp.check_output(["chmod", "-R", "-f", "o+w", local_base_dir, "||", "true"])
 
         json_path_cached_mod = json_path_cached.replace(".json", ".mod.json")
         original_dir = None

--- a/common/datasets/sms_wsj/returnn_datasets.py
+++ b/common/datasets/sms_wsj/returnn_datasets.py
@@ -19,7 +19,7 @@ from returnn.datasets.hdf import HDFDataset
 from returnn.datasets.map import MapDatasetBase, MapDatasetWrapper
 
 # noinspection PyUnresolvedReferences
-from returnn.log import log
+from returnn.log import log as returnn_log
 
 # noinspection PyUnresolvedReferences
 from returnn.util.basic import OptionalNotImplementedError, NumbersDict
@@ -145,7 +145,7 @@ class SmsWsjBase(MapDatasetBase):
         if not (min(keys) <= seq_idx <= max(keys)):
             print(
                 f"WARNING: seq_idx {seq_idx} outside range of keys: {self._buffer.keys()}",
-                file=log.v5
+                file=returnn_log.v5
             )
 
         # add sequences
@@ -153,7 +153,7 @@ class SmsWsjBase(MapDatasetBase):
             if idx not in self._buffer:
                 self._buffer[idx] = next(self._ds_iterator)
             if idx == len(self) - 1 and 0 not in self._buffer:
-                print(f"Reached end of dataset, reset iterator", file=log.v4)
+                print(f"Reached end of dataset, reset iterator", file=returnn_log.v4)
                 try:
                     next(self._ds_iterator)
                 except StopIteration:
@@ -162,16 +162,16 @@ class SmsWsjBase(MapDatasetBase):
                     print(
                         "WARNING: reached final index of dataset, but iterator has more sequences. "
                         "Maybe the training was restarted from an epoch > 1?",
-                        file=log.v3
+                        file=returnn_log.v3
                     )
-                print(f"Current buffer indices: {self._buffer.keys()}", file=log.v5)
+                print(f"Current buffer indices: {self._buffer.keys()}", file=returnn_log.v5)
                 self._ds_iterator = iter(self._ds)
                 for idx_ in range(min(self._buffer_size // 2, len(self))):
                     if idx_ not in self._buffer:
                         self._buffer[idx_] = next(self._ds_iterator)
                 print(
                     f"After adding start of dataset to buffer indices: {self._buffer.keys()}",
-                    file=log.v5
+                    file=returnn_log.v5
                 )
 
         # remove sequences
@@ -196,7 +196,7 @@ class SmsWsjBase(MapDatasetBase):
         Caches and unzips a given archive with SMS-WSJ data which will then be used as data dir.
         This is done because caching of the single files takes extremely long.
         """
-        print(f"Cache and unzip SMS-WSJ data from {zip_cache}", file=log.v4)
+        print(f"Cache and unzip SMS-WSJ data from {zip_cache}", file=returnn_log.v4)
 
         # cache file
         try:
@@ -212,7 +212,7 @@ class SmsWsjBase(MapDatasetBase):
         except sp.CalledProcessError:
             print(
                 f"Cache manager: Error occurred when caching and unzipping {zip_cache}",
-                file=log.v2
+                file=returnn_log.v2
             )
             raise
 
@@ -269,7 +269,7 @@ class SmsWsjBase(MapDatasetBase):
 
         print(
             f"Finished preparation of zip cache data, use json in {json_path_cached_mod}",
-            file=log.v4
+            file=returnn_log.v4
         )
         return json_path_cached_mod
 
@@ -352,7 +352,7 @@ class SmsWsjWrapper(MapDatasetWrapper):
         :param Optional[SmsWsjBase] sms_wsj_base: SMS-WSJ base class to allow inherited classes to modify this
         """
         if "seq_ordering" not in kwargs:
-            print("Warning: no shuffling is enabled by default", file=log.v2)
+            print("Warning: no shuffling is enabled by default", file=returnn_log.v2)
         super().__init__(sms_wsj_base, **kwargs)
         # self.num_outputs = ...  # needs to be set in derived classes
 

--- a/common/datasets/sms_wsj/returnn_datasets.py
+++ b/common/datasets/sms_wsj/returnn_datasets.py
@@ -217,9 +217,10 @@ class SmsWsjBase(MapDatasetBase):
             raise
 
         # unzip
-        sp.check_call(
-            ["unzip", "-q", "-n", zip_cache_cached, "-d", local_base_dir]
-        )
+        unzip_cmd = ["unzip", "-q", "-n", zip_cache_cached, "-d", local_base_dir]
+        print(" ".join(unzip_cmd), file=returnn_log.v4)
+        sp.check_call(unzip_cmd)
+        print("Finished unzipping", file=returnn_log.v4)
         sp.check_call(["chmod", "-R", "o+w", local_base_dir])
 
         json_path_cached_mod = json_path_cached.replace(".json", ".mod.json")

--- a/common/datasets/sms_wsj/returnn_datasets.py
+++ b/common/datasets/sms_wsj/returnn_datasets.py
@@ -19,16 +19,10 @@ from returnn.datasets.hdf import HDFDataset
 from returnn.datasets.map import MapDatasetBase, MapDatasetWrapper
 
 # noinspection PyUnresolvedReferences
-from returnn.datasets.util.vocabulary import BytePairEncoding
-
-# noinspection PyUnresolvedReferences
 from returnn.log import log
 
 # noinspection PyUnresolvedReferences
 from returnn.util.basic import OptionalNotImplementedError, NumbersDict
-
-# noinspection PyUnresolvedReferences
-from sms_wsj.database import SmsWsj, AudioReader, scenario_map_fn
 
 
 class SmsWsjBase(MapDatasetBase):
@@ -59,6 +53,9 @@ class SmsWsjBase(MapDatasetBase):
         :param Optional[str] zip_cache: zip archive with SMS-WSJ data which can be cached, unzipped and used as data dir
         :param Optional[Dict] scenario_map_args: optional kwargs for sms_wsj scenario_map_fn
         """
+        # noinspection PyUnresolvedReferences
+        from sms_wsj.database import SmsWsj, AudioReader, scenario_map_fn
+
         super(SmsWsjBase, self).__init__(**kwargs)
 
         self.data_types = data_types
@@ -564,6 +561,8 @@ class SmsWsjMixtureEarlyBpeDataset(SmsWsjMixtureEarlyDataset):
         :param Optional[Dict[str, List[int]]] num_outputs: num_outputs for RETURNN dataset
         :param Optional[str] zip_cache: zip archive with SMS-WSJ data which can be cached, unzipped and used as data dir
         """
+        from returnn.datasets.util.vocabulary import BytePairEncoding
+
         self.bpe = BytePairEncoding(**bpe)
         data_types = {
             "target_signals": {"dim": 2, "shape": (None, 2)},

--- a/common/datasets/sms_wsj/returnn_datasets.py
+++ b/common/datasets/sms_wsj/returnn_datasets.py
@@ -29,6 +29,7 @@ class SequenceBuffer(dict):
     """
     Helper class to represent a buffer of sequences
     """
+
     def __init__(self, max_size: int):
         super().__init__()
         self._max_size = max_size
@@ -102,9 +103,9 @@ class SmsWsjBase(MapDatasetBase):
 
         self._use_buffer = buffer
         if self._use_buffer:
-            self._ds = self._ds.prefetch(
-                prefetch_num_workers, buffer_size
-            ).copy(freeze=True)
+            self._ds = self._ds.prefetch(prefetch_num_workers, buffer_size).copy(
+                freeze=True
+            )
         self._buffer = SequenceBuffer(buffer_size)
 
     def __len__(self) -> int:
@@ -164,7 +165,7 @@ class SmsWsjBase(MapDatasetBase):
         if not (min(keys) <= seq_idx <= max(keys)):
             print(
                 f"WARNING: seq_idx {seq_idx} outside range of keys: {self._buffer.keys()}",
-                file=returnn_log.v5
+                file=returnn_log.v5,
             )
 
         # add sequences
@@ -181,16 +182,19 @@ class SmsWsjBase(MapDatasetBase):
                     print(
                         "WARNING: reached final index of dataset, but iterator has more sequences. "
                         "Maybe the training was restarted from an epoch > 1?",
-                        file=returnn_log.v3
+                        file=returnn_log.v3,
                     )
-                print(f"Current buffer indices: {self._buffer.keys()}", file=returnn_log.v5)
+                print(
+                    f"Current buffer indices: {self._buffer.keys()}",
+                    file=returnn_log.v5,
+                )
                 self._ds_iterator = iter(self._ds)
                 for idx_ in range(min(self._buffer.max_size // 2, len(self))):
                     if idx_ not in self._buffer:
                         self._buffer[idx_] = next(self._ds_iterator)
                 print(
                     f"After adding start of dataset to buffer indices: {self._buffer.keys()}",
-                    file=returnn_log.v5
+                    file=returnn_log.v5,
                 )
 
     @staticmethod
@@ -215,7 +219,7 @@ class SmsWsjBase(MapDatasetBase):
         except sp.CalledProcessError:
             print(
                 f"Cache manager: Error occurred when caching and unzipping {zip_cache}",
-                file=returnn_log.v2
+                file=returnn_log.v2,
             )
             raise
 
@@ -273,7 +277,7 @@ class SmsWsjBase(MapDatasetBase):
 
         print(
             f"Finished preparation of zip cache data, use json in {json_path_cached_mod}",
-            file=returnn_log.v4
+            file=returnn_log.v4,
         )
         return json_path_cached_mod
 
@@ -518,7 +522,7 @@ class SmsWsjMixtureEarlyAlignmentDataset(SmsWsjMixtureEarlyDataset):
             self.num_outputs = num_outputs
         else:
             assert (
-                    classes_num_outputs is not None
+                classes_num_outputs is not None
             ), "either num_outputs or classes_num_outputs has to be given"
             self.num_outputs["target_classes"] = [
                 classes_num_outputs,

--- a/common/datasets/sms_wsj/returnn_datasets.py
+++ b/common/datasets/sms_wsj/returnn_datasets.py
@@ -109,10 +109,7 @@ class SmsWsjBase(MapDatasetBase):
         """
         Returns tag for the sequence of the given index, default is 'seq-{seq_idx}'.
         """
-        if "seq_tag" in self._get_seq_by_idx(seq_idx):
-            return str(self._get_seq_by_idx(seq_idx)["seq_tag"])
-        else:
-            return "seq-%i" % seq_idx
+        return str(self._get_seq_by_idx(seq_idx).get("seq_tag", f"seq-{seq_idx}"))
 
     def get_seq_len(self, seq_idx: int) -> int:
         """

--- a/common/datasets/sms_wsj/returnn_datasets.py
+++ b/common/datasets/sms_wsj/returnn_datasets.py
@@ -228,7 +228,7 @@ class SmsWsjBase(MapDatasetBase):
         print(" ".join(unzip_cmd), file=returnn_log.v4)
         sp.check_call(unzip_cmd)
         print("Finished unzipping", file=returnn_log.v4)
-        sp.check_call(["chmod", "-R", "o+w", local_base_dir])
+        sp.check_call(["chmod", "-R", "-f", "o+w", local_base_dir])
 
         json_path_cached_mod = json_path_cached.replace(".json", ".mod.json")
         original_dir = None

--- a/common/datasets/sms_wsj/returnn_datasets.py
+++ b/common/datasets/sms_wsj/returnn_datasets.py
@@ -313,8 +313,8 @@ class SmsWsjBaseWithHdfClasses(SmsWsjBase):
             for hdf_seq_tag in hdf_seq_tags
         ]
         padded_len = max(hdf_classes_.shape[0] for hdf_classes_ in hdf_classes)
-        for speaker_idx, rasr_target in enumerate(hdf_classes):
-            total_pad_frames = padded_len - rasr_target.shape[0]
+        for speaker_idx, hdf_classes_speaker in enumerate(hdf_classes):
+            total_pad_frames = padded_len - hdf_classes_speaker.shape[0]
             if total_pad_frames == 0:
                 continue
             pad_start = int(round(d["offset"][speaker_idx] / d["seq_len"] * padded_len))

--- a/common/datasets/sms_wsj/returnn_datasets.py
+++ b/common/datasets/sms_wsj/returnn_datasets.py
@@ -229,7 +229,6 @@ class SmsWsjBase(MapDatasetBase):
         else:
             print(f"Unzipped audio already exists in {local_unzipped_dir}")
 
-
         json_path_cached_mod = json_path_cached.replace(".json", ".mod.json")
         original_dir = None
         if not os.path.exists(json_path_cached_mod):
@@ -263,9 +262,9 @@ class SmsWsjBase(MapDatasetBase):
                         ][seq_idx]
                         if not os.path.exists(json_path_cached_mod):
                             path = path.replace(original_dir, local_unzipped_dir)
-                            json_dict["datasets"][dataset_name][seq]["audio_path"][audio_key][
-                                seq_idx
-                            ] = path
+                            json_dict["datasets"][dataset_name][seq]["audio_path"][
+                                audio_key
+                            ][seq_idx] = path
                         assert path.startswith(
                             local_unzipped_dir
                         ), f"Audio file {path} was expected to start with {local_unzipped_dir}"
@@ -275,7 +274,9 @@ class SmsWsjBase(MapDatasetBase):
             with open(json_path_cached_mod, "w", encoding="utf-8") as f:
                 json.dump(json_dict, f, ensure_ascii=False, indent=4)
 
-        print(f"Finished preparation of zip cache data, use json in {json_path_cached_mod}")
+        print(
+            f"Finished preparation of zip cache data, use json in {json_path_cached_mod}"
+        )
         return json_path_cached_mod
 
 

--- a/common/datasets/sms_wsj/returnn_datasets.py
+++ b/common/datasets/sms_wsj/returnn_datasets.py
@@ -128,7 +128,7 @@ class SmsWsjBase(MapDatasetBase):
         data = self[seq_idx]
         d = {k: v.size for k, v in data.items()}
         for update_key in ["data", "target_signals"]:
-            if update_key in d.keys() and "seq_len" in data:
+            if update_key in d and "seq_len" in data:
                 d[update_key] = int(data["seq_len"])
         return NumbersDict(d)
 

--- a/common/datasets/sms_wsj/returnn_datasets.py
+++ b/common/datasets/sms_wsj/returnn_datasets.py
@@ -314,13 +314,13 @@ class SmsWsjBaseWithHdfClasses(SmsWsjBase):
             for hdf_seq_tag in hdf_seq_tags
         ]
         padded_len = max(hdf_classes_.shape[0] for hdf_classes_ in hdf_classes)
-        for speaker_idx in range(len(hdf_classes)):
-            pad_start = int(round(d["offset"][speaker_idx] / d["seq_len"] * padded_len))
-            pad_end = padded_len - hdf_classes[speaker_idx].shape[0] - pad_start
-            if pad_end < 0:
-                pad_start += pad_end
-                assert pad_start >= 0
-                pad_end = 0
+        for speaker_idx, rasr_target in enumerate(hdf_classes):
+            total_pad_frames = padded_len - rasr_target.shape[0]
+            if total_pad_frames == 0:
+                continue
+            pad_start = round(d["offset"][speaker_idx] / d["seq_len"] * padded_len)
+            pad_start = min(pad_start, total_pad_frames)
+            pad_end = total_pad_frames - pad_start
             if pad_start or pad_end:
                 assert self._pad_label is not None, "Label for padding is needed"
             hdf_classes[speaker_idx] = np.concatenate(

--- a/common/datasets/sms_wsj/returnn_datasets.py
+++ b/common/datasets/sms_wsj/returnn_datasets.py
@@ -115,10 +115,11 @@ class SmsWsjBase(MapDatasetBase):
         """
         Returns length of the sequence of the given index
         """
-        if "seq_len" in self._get_seq_by_idx(seq_idx):
+        try:
             return int(self._get_seq_by_idx(seq_idx)["seq_len"])
-        else:
+        except KeyError:
             raise OptionalNotImplementedError
+            
 
     def get_seq_length_for_keys(self, seq_idx: int) -> NumbersDict:
         """


### PR DESCRIPTION
I added some helper classes which allow wrapping the [SMS-WSJ dataset](https://github.com/fgnt/sms_wsj/) in RETURNN. They basically wrap RETURNN's `MapDatasetBase` and `MapDatasetWrapper`. They are part of `i6_experiments` to allow integrating them into a pipeline. An example usage in the sisyphus config would be
```
def segment_to_rasr(seg_name):
    """
    Maps SMS-WSJ segnemt name (e.g. "0_4k6c0303_4k4c0319") to list of RASR segment names
    (e.g. ["cv_dev93/4k6c0303/0000", "cv_dev93/4k4c0319/0000"]), which can be found in HDF.
    """
    segs = str(seg_name).split("_")[1:]
    return [f"cv_dev93/{seg}/0000" for seg in segs]


returnn_config = ReturnnConfig(
  dict(
    dev={
      "class": CodeWrapper("SmsWsjMixtureEarlyAlignmentDataset"),
      "dataset_name": "cv_dev93",
      "json_path": "/path/to/sms_wsj.json",
      "rasr_num_outputs": 9001,
      "segment_to_rasr": segment_to_rasr
      "rasr_classes_hdf": "/path/to/cv_dev93_alignments.hdf",
      "pad_label": 9000,
      "seq_ordering": "default",
    },
    ...
  ),
  python_prolog=[
    SmsWsjBase,
    SmsWsjBaseWithRasrClasses,
    SmsWsjWrapper,
    SmsWsjMixtureEarlyDataset,
    SmsWsjMixtureEarlyAlignmentDataset,
  ],
  ...
)
```
I will add a baseline pipeline for a joint separation and recognition system lateron.
