### PR TITLE
update sequitur version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-sequitur-g2p==1.0.1668.7
+sequitur-g2p==1.0.1668.23


### PR DESCRIPTION
Originally I planned to keep Sequitur fix, but under Ubuntu 22 and Python 3.10 the currently pinned version no longer installs.