### PR TITLE
OggZipHdfDataInput more flexible

### DIFF
--- a/common/setups/rasr/util/nn.py
+++ b/common/setups/rasr/util/nn.py
@@ -170,9 +170,9 @@ class OggZipHdfDataInput:
         :param targets:
         :param partition_epoch:
         :param seq_ordering:
-        :param ogg_args
-        :param meta_args
-        :param acoustic_mixtures
+        :param ogg_args: parameters for the `OggZipDataset`.
+        :param meta_args: parameters for the `MetaDataset`.
+        :param acoustic_mixtures: path to a RASR acoustic mixture file
         """
         self.oggzip_files = oggzip_files
         self.alignments = alignments

--- a/common/setups/rasr/util/nn.py
+++ b/common/setups/rasr/util/nn.py
@@ -153,48 +153,45 @@ class OggZipHdfDataInput:
         self,
         oggzip_files: List[tk.Path],
         alignments: List[tk.Path],
-        context_window: Dict,
         audio: Dict,
-        targets: Optional[str] = None,
         partition_epoch: int = 1,
         seq_ordering: str = "laplace:.1000",
-        ogg_args: Optional[Dict[str, Any]] = None,
         meta_args: Optional[Dict[str, Any]] = None,
+        ogg_args: Optional[Dict[str, Any]] = None,
+        hdf_args: Optional[Dict[str, Any]] = None,
         acoustic_mixtures: Optional[tk.Path] = None,
     ):
         """
-        :param oggzip_files:
-        :param alignments:
-        :param context_window: {"classes": 1, "data": 242}
+        :param oggzip_files: zipped ogg files which contain the audio
+        :param alignments: hdf files which contain dumped RASR alignments
         :param audio: e.g. {"features": "raw", "sample_rate": 16000} for raw waveform input with a sample rate of 16 kHz
-        :param targets:
-        :param partition_epoch:
-        :param seq_ordering:
-        :param ogg_args: parameters for the `OggZipDataset`
+        :param partition_epoch: if >1, split the full dataset into multiple sub-epochs
+        :param seq_ordering: sort the sequences in the dataset, e.g. "random" or "laplace:.100"
         :param meta_args: parameters for the `MetaDataset`
-        :param acoustic_mixtures: path to a RASR acoustic mixture file
+        :param ogg_args: parameters for the `OggZipDataset`
+        :param hdf_args: parameters for the `HdfDataset`
+        :param acoustic_mixtures: path to a RASR acoustic mixture file (used in System classes, not RETURNN training)
         """
         self.oggzip_files = oggzip_files
         self.alignments = alignments
-        self.context_window = context_window
         self.audio = audio
         self.partition_epoch = partition_epoch
         self.seq_ordering = seq_ordering
-        self.targets = targets
-        self.ogg_args = ogg_args
         self.meta_args = meta_args
+        self.ogg_args = ogg_args
+        self.hdf_args = hdf_args
         self.acoustic_mixtures = acoustic_mixtures
 
     def get_data_dict(self):
         return {
             "class": "MetaDataset",
-            "context_window": self.context_window,
             "data_map": {"classes": ("hdf", "classes"), "data": ("ogg", "data")},
             "datasets": {
                 "hdf": {
                     "class": "HDFDataset",
                     "files": self.alignments,
                     "use_cache_manager": True,
+                    **(self.hdf_args or {}),
                 },
                 "ogg": {
                     "class": "OggZipDataset",
@@ -202,7 +199,6 @@ class OggZipHdfDataInput:
                     "partition_epoch": self.partition_epoch,
                     "path": self.oggzip_files,
                     "seq_ordering": self.seq_ordering,
-                    "targets": self.targets,
                     "use_cache_manager": True,
                     **(self.ogg_args or {}),
                 },

--- a/common/setups/rasr/util/nn.py
+++ b/common/setups/rasr/util/nn.py
@@ -170,8 +170,8 @@ class OggZipHdfDataInput:
         :param targets:
         :param partition_epoch:
         :param seq_ordering:
-        :param ogg_args: parameters for the `OggZipDataset`.
-        :param meta_args: parameters for the `MetaDataset`.
+        :param ogg_args: parameters for the `OggZipDataset`
+        :param meta_args: parameters for the `MetaDataset`
         :param acoustic_mixtures: path to a RASR acoustic mixture file
         """
         self.oggzip_files = oggzip_files

--- a/common/setups/rasr/util/nn.py
+++ b/common/setups/rasr/util/nn.py
@@ -159,6 +159,7 @@ class OggZipHdfDataInput:
         partition_epoch: int = 1,
         seq_ordering: str = "laplace:.1000",
         ogg_args: Optional[Dict[str, Any]] = None,
+        meta_args: Optional[Dict[str, Any]] = None,
         acoustic_mixtures: Optional[tk.Path] = None,
     ):
         """
@@ -166,9 +167,12 @@ class OggZipHdfDataInput:
         :param alignments:
         :param context_window: {"classes": 1, "data": 242}
         :param audio: e.g. {"features": "raw", "sample_rate": 16000} for raw waveform input with a sample rate of 16 kHz
+        :param targets:
         :param partition_epoch:
         :param seq_ordering:
-        :param targets:
+        :param ogg_args
+        :param meta_args
+        :param acoustic_mixtures
         """
         self.oggzip_files = oggzip_files
         self.alignments = alignments
@@ -178,6 +182,7 @@ class OggZipHdfDataInput:
         self.seq_ordering = seq_ordering
         self.targets = targets
         self.ogg_args = ogg_args
+        self.meta_args = meta_args
         self.acoustic_mixtures = acoustic_mixtures
 
     def get_data_dict(self):
@@ -203,6 +208,7 @@ class OggZipHdfDataInput:
                 },
             },
             "seq_order_control_dataset": "ogg",
+            **(self.meta_args or {}),
         }
 
 

--- a/common/setups/rasr/util/nn.py
+++ b/common/setups/rasr/util/nn.py
@@ -152,7 +152,7 @@ class OggZipHdfDataInput:
     def __init__(
         self,
         oggzip_files: List[tk.Path],
-        alignments: tk.Path,
+        alignments: List[tk.Path],
         context_window: Dict,
         audio: Dict,
         targets: Optional[str] = None,
@@ -193,7 +193,7 @@ class OggZipHdfDataInput:
             "datasets": {
                 "hdf": {
                     "class": "HDFDataset",
-                    "files": [self.alignments.get_path()],
+                    "files": self.alignments,
                     "use_cache_manager": True,
                 },
                 "ogg": {


### PR DESCRIPTION
I'd like to make `OggZipHdfDataInput` a bit more flexible. `meta_args` allows passing kwargs for the `MetaDataset` similar to `ogg_args`. Additionally, I'd like to pass a list of paths for `alignment`. Do people except for me already use this? Then I would need to modify the PR in order to preserve hashes and behavior.