### PR TITLE
importable librispeech 960 gmm baseline

### DIFF
--- a/common/baselines/librispeech/ls960/gmm/baseline_config.py
+++ b/common/baselines/librispeech/ls960/gmm/baseline_config.py
@@ -17,6 +17,7 @@ from ...default_tools import RASR_BINARY_PATH
 
 def run_librispeech_960_common_baseline(
     alias_prefix="baselines/librispeech/ls960/gmm/common_baseline",
+    recognition=True,
 ):
 
     # the RASR-System pipelines need global alias and output settings
@@ -61,8 +62,8 @@ def run_librispeech_960_common_baseline(
     system.init_system(
         rasr_init_args=rasr_init_args,
         train_data=corpus_data.train_data,
-        dev_data=corpus_data.dev_data,
-        test_data=corpus_data.test_data,
+        dev_data=corpus_data.dev_data if recognition else {},
+        test_data=corpus_data.test_data if recognition else {},
     )
 
     # run everything
@@ -70,3 +71,5 @@ def run_librispeech_960_common_baseline(
 
     # recover alias and output path settings
     gs.ALIAS_AND_OUTPUT_SUBDIR = stored_alias_subdir
+
+    return system


### PR DESCRIPTION
For some setup, I'd like to import the Librispeech 960h GMM baseline pipeline to get the alignments from it. I just care about the alignments, so I don't want to run recognition (not all jobs could be imported from `/work/common/asr/` and I don't want to run them since I don't need them). These small changes allow to facilitate this.