### PR TITLE
Extend ReturnnRasrDataInput to produce valid Dataset config dict

### DIFF
--- a/common/setups/rasr/util/nn.py
+++ b/common/setups/rasr/util/nn.py
@@ -10,7 +10,6 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple, Type, TypedDict, Union
 
 from sisyphus import tk
-from sisyphus.delayed_ops import DelayedFormat
 
 import i6_core.am as am
 import i6_core.rasr as rasr
@@ -199,44 +198,46 @@ class OggZipHdfDataInput:
     def __init__(
         self,
         oggzip_files: List[tk.Path],
-        alignments: tk.Path,
-        context_window: Dict,
+        alignments: List[tk.Path],
         audio: Dict,
-        targets: Optional[str] = None,
         partition_epoch: int = 1,
         seq_ordering: str = "laplace:.1000",
+        meta_args: Optional[Dict[str, Any]] = None,
         ogg_args: Optional[Dict[str, Any]] = None,
+        hdf_args: Optional[Dict[str, Any]] = None,
         acoustic_mixtures: Optional[tk.Path] = None,
     ):
         """
-        :param oggzip_files:
-        :param alignments:
-        :param context_window: {"classes": 1, "data": 242}
+        :param oggzip_files: zipped ogg files which contain the audio
+        :param alignments: hdf files which contain dumped RASR alignments
         :param audio: e.g. {"features": "raw", "sample_rate": 16000} for raw waveform input with a sample rate of 16 kHz
-        :param partition_epoch:
-        :param seq_ordering:
-        :param targets:
+        :param partition_epoch: if >1, split the full dataset into multiple sub-epochs
+        :param seq_ordering: sort the sequences in the dataset, e.g. "random" or "laplace:.100"
+        :param meta_args: parameters for the `MetaDataset`
+        :param ogg_args: parameters for the `OggZipDataset`
+        :param hdf_args: parameters for the `HdfDataset`
+        :param acoustic_mixtures: path to a RASR acoustic mixture file (used in System classes, not RETURNN training)
         """
         self.oggzip_files = oggzip_files
         self.alignments = alignments
-        self.context_window = context_window
         self.audio = audio
         self.partition_epoch = partition_epoch
         self.seq_ordering = seq_ordering
-        self.targets = targets
+        self.meta_args = meta_args
         self.ogg_args = ogg_args
+        self.hdf_args = hdf_args
         self.acoustic_mixtures = acoustic_mixtures
 
     def get_data_dict(self):
         return {
             "class": "MetaDataset",
-            "context_window": self.context_window,
             "data_map": {"classes": ("hdf", "classes"), "data": ("ogg", "data")},
             "datasets": {
                 "hdf": {
                     "class": "HDFDataset",
-                    "files": [self.alignments.get_path()],
+                    "files": self.alignments,
                     "use_cache_manager": True,
+                    **(self.hdf_args or {}),
                 },
                 "ogg": {
                     "class": "OggZipDataset",
@@ -244,12 +245,12 @@ class OggZipHdfDataInput:
                     "partition_epoch": self.partition_epoch,
                     "path": self.oggzip_files,
                     "seq_ordering": self.seq_ordering,
-                    "targets": self.targets,
                     "use_cache_manager": True,
                     **(self.ogg_args or {}),
                 },
             },
             "seq_order_control_dataset": "ogg",
+            **(self.meta_args or {}),
         }
 
 

--- a/common/setups/rasr/util/nn.py
+++ b/common/setups/rasr/util/nn.py
@@ -75,7 +75,7 @@ class ReturnnRasrDataInput:
         feature_flow = returnn.ReturnnRasrTrainingJob.create_flow(self.feature_flow, self.alignments)
         write_feature_flow = rasr.WriteFlowNetworkJob(feature_flow)
         return write_feature_flow.out_flow_file
-    
+
     def get_training_rasr_config(self) -> tk.Path:
         config, post_config = returnn.ReturnnRasrTrainingJob.create_config(
             self.crp,
@@ -91,18 +91,15 @@ class ReturnnRasrDataInput:
         config.neural_network_trainer.feature_extraction.file = self.get_training_feature_flow()
         write_rasr_config = rasr.WriteRasrConfigJob(config, post_config)
         return write_rasr_config.out_config
-    
+
     def get_data_dict(self) -> Dict[str, Union[str, DelayedFormat, tk.Path]]:
         """Returns the data dict for the ExternSprintDataset to be used in a training ReturnnConfig."""
         config_file = self.get_training_rasr_config()
-        config_str = DelayedFormat(
-            "--config={} --*.LOGFILE=nn-trainer.{}.log --*.TASK=1",
-            config_file, self.name
-        )
-        dataset = { 
-            'class'                 : 'ExternSprintDataset',
-            'sprintTrainerExecPath' : rasr.RasrCommand.select_exe(self.crp.nn_trainer_exe, 'nn-trainer'),
-            'sprintConfigStr'       : config_str,
+        config_str = DelayedFormat("--config={} --*.LOGFILE=nn-trainer.{}.log --*.TASK=1", config_file, self.name)
+        dataset = {
+            "class": "ExternSprintDataset",
+            "sprintTrainerExecPath": rasr.RasrCommand.select_exe(self.crp.nn_trainer_exe, "nn-trainer"),
+            "sprintConfigStr": config_str,
         }
         if self.partition_epochs is not None:
             dataset["partitionEpoch"] = self.partition_epochs

--- a/common/setups/rasr/util/nn.py
+++ b/common/setups/rasr/util/nn.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple, Type, TypedDict, Union
 
 from sisyphus import tk
+from sisyphus.delayed_ops import DelayedFormat
 
 import i6_core.am as am
 import i6_core.rasr as rasr

--- a/common/setups/rasr/util/nn.py
+++ b/common/setups/rasr/util/nn.py
@@ -94,7 +94,7 @@ class ReturnnRasrDataInput:
     
     def get_data_dict(self) -> Dict[str, Union[str, DelayedFormat, tk.Path]]:
         """Returns the data dict for the ExternSprintDataset to be used in a training ReturnnConfig."""
-        config_file = self.get_rasr_training_config()
+        config_file = self.get_training_rasr_config()
         config_str = DelayedFormat(
             "--config={} --*.LOGFILE=nn-trainer.{}.log --*.TASK=1",
             config_file, self.name


### PR DESCRIPTION
Similar to the `OggZipHdfDataInput` the `ReturnnRasrDataInput` gets a working `get_data_dict` implementation. This is useful for replacing the `ReturnnRasrTrainingJob` with the standard `ReturnnTrainingJob` for more functionality, e.g. producing different feature flow files for train and dev (see also [this discussion](https://github.com/rwth-i6/i6_core/issues/165))