### PR TITLE
fix: Format optimized pronunciation_scale via DelayedFormat

### DIFF
--- a/common/setups/rasr/base_decoder.py
+++ b/common/setups/rasr/base_decoder.py
@@ -187,7 +187,7 @@ class BaseDecoder:
         tdp_speech: Tdp,
         tdp_silence: Tdp,
         tdp_nonspeech: Optional[Tdp] = None,
-        pronunciation_scale: Optional[float] = None,
+        pronunciation_scale: Optional[Union[float, tk.Variable]] = None,
         altas: Optional[float] = None,
     ) -> Union[str, DelayedBase]:
         """
@@ -215,7 +215,10 @@ class BaseDecoder:
             out_str += f"_tdpnonspeech{tdp_nonspeech}"
 
         if pronunciation_scale is not None:
-            out_str += f"_ps{pronunciation_scale:05.2f}"
+            if isinstance(pronunciation_scale, tk.Variable):
+                out_str += DelayedFormat("_ps{}", pronunciation_scale)
+            else:
+                out_str += f"_ps{pronunciation_scale:05.2f}"
 
         if altas is not None:
             out_str += f"_altas{altas:05.2f}"


### PR DESCRIPTION
When optimizing LM/AM scales, the previous code tried formatting a sisyphus variable using an unsupported format string. This PR changes the code to use `DelayedFormat`, which works out.

```
~/setups/2023-04--thesis-baselines/recipe/i6_experiments/common/setups/rasr/base_decoder.py in _set_scales_and_tdps(self=<i6_experiments.common.setups.rasr.hybrid_decoder.HybridDecoder object>, corpus_key='dev-other/', am_scale=1, lm_scale=<Variable work/i6_core/recognition/optimize_para...MandLMScaleJob.z9XfhcAyMZ7m/output/bast_lm_score>, prior_scale=0.2, tdp_s
cale=0.6, tdp_speech=Tdp(loop=3.0, forward=0.0, skip='infinity', exit=0.0), tdp_silence=Tdp(loop=0.0, forward=3.0, skip='infinity', exit=20.0), tdp_nonspeech=Tdp(loop=0.0, forward=3.0, skip='infinity', exit=20.0), pronunciation_scale=<Variable work/i6_core/recognition/optimize_para...MandLMScaleJob.z9XfhcAyMZ7m/output/bast_am_score>, altas=2)
    241         base_corpus_key = corpus_key
    242         corpus_key += "/"
--> 243         corpus_key += self._get_scales_string(
        corpus_key = 'dev-other/'
        self._get_scales_string = <function BaseDecoder._get_scales_string at 0x7fb1ba22a8b0>
        am_scale = 1
        lm_scale = <Variable work/i6_core/recognition/optimize_parameters/OptimizeAMandLMScaleJob.z9XfhcAyMZ7m/output/bast_lm_score>
        prior_scale = 0.2
        tdp_scale = 0.6
        tdp_speech = Tdp(loop=3.0, forward=0.0, skip='infinity', exit=0.0)
        tdp_silence = Tdp(loop=0.0, forward=3.0, skip='infinity', exit=20.0)
        tdp_nonspeech = Tdp(loop=0.0, forward=3.0, skip='infinity', exit=20.0)
        pronunciation_scale = <Variable work/i6_core/recognition/optimize_parameters/OptimizeAMandLMScaleJob.z9XfhcAyMZ7m/output/bast_am_score>
        altas = 2
    244             am_scale=am_scale,
    245             lm_scale=lm_scale,

~/setups/2023-04--thesis-baselines/recipe/i6_experiments/common/setups/rasr/base_decoder.py in _get_scales_string(am_scale=1, lm_scale=<Variable work/i6_core/recognition/optimize_para...MandLMScaleJob.z9XfhcAyMZ7m/output/bast_lm_score>, prior_scale=0.2, tdp_scale=0.6, tdp_speech=Tdp(loop=3.0, forward=0.0, skip='infinity', exit=0.0), tdp_silence=Tdp(loop=0.0, for
ward=3.0, skip='infinity', exit=20.0), tdp_nonspeech=Tdp(loop=0.0, forward=3.0, skip='infinity', exit=20.0), pronunciation_scale=<Variable work/i6_core/recognition/optimize_para...MandLMScaleJob.z9XfhcAyMZ7m/output/bast_am_score>, altas=2)
    216
    217         if pronunciation_scale is not None:
--> 218             out_str += f"_ps{pronunciation_scale:05.2f}"
        out_str = am01.00_lmNone_prior00.20_tdp0.6_tdpspeechloop3.0_forward0.0_skipinfinity_exit0.0_tdpsilenceloop0.0_forward3.0_skipinfinity_exit20.0_tdpnonspeechloop0.0_forward3.0_skipinfinity_exit20.0
    219
    220         if altas is not None:

TypeError: unsupported format string passed to Variable.__format__
```