### PR TITLE
Rework shuffling options for ReturnnRasrDataInput

### DIFF
--- a/common/setups/rasr/util/nn.py
+++ b/common/setups/rasr/util/nn.py
@@ -54,18 +54,6 @@ class ReturnnRasrTrainingArgs:
 class ReturnnRasrDataInput:
     """
     Holds the data for ReturnnRasrTrainingJob.
-
-    :param name: name of the data
-    :param crp: common RASR parameters
-    :param alignments: RASR cache of an alignment
-    :param feature_flow: acoustic feature flow network or dict of feature flow networks
-    :param features: RASR cache of acoustic features
-    :param acoustic_mixtures: path to a RASR acoustic mixture file (used in System classes, not RETURNN training)
-    :param feature_scorers: RASR feature scorers
-    :param shuffle_data: shuffle training segments into bins of similar length. The bins are sorted by length.
-    :param stm: stm file for scoring
-    :param glm: glm file for scoring
-    :param returnn_rasr_training_args: arguments for RETURNN training with RASR
     """
 
     def __init__(
@@ -77,12 +65,29 @@ class ReturnnRasrDataInput:
         features: Optional[Union[RasrCacheTypes, Dict[str, RasrCacheTypes]]] = None,
         acoustic_mixtures: Optional[Union[tk.Path, str]] = None,
         feature_scorers: Optional[Dict[str, Type[rasr.FeatureScorer]]] = None,
-        shuffling_parameters: Optional[Dict] = None,
+        shuffle_data: bool = True,
+        shuffling_parameters: Optional[Dict[str, Any]] = None,
         stm: Optional[tk.Path] = None,
         glm: Optional[tk.Path] = None,
         returnn_rasr_training_args: Optional[ReturnnRasrTrainingArgs] = None,
         **kwargs,
     ):
+        """
+
+        :param name: name of the data
+        :param crp: common RASR parameters
+        :param alignments: RASR cache of an alignment
+        :param feature_flow: acoustic feature flow network or dict of feature flow networks
+        :param features: RASR cache of acoustic features
+        :param acoustic_mixtures: path to a RASR acoustic mixture file (used in System classes, not RETURNN training)
+        :param feature_scorers: RASR feature scorers
+        :param shuffle_data: shuffle training segments into bins of similar length. The bins are sorted by length.
+        :param shuffling_parameters: Dict of additional parameters to set for shuffling,
+            currently only 'segment_order_sort_by_time_length_chunk_size' is supported
+        :param stm: stm file for scoring
+        :param glm: glm file for scoring
+        :param returnn_rasr_training_args: arguments for RETURNN training with RASR
+        """
         self.name = name
         self.crp = crp
         self.alignments = alignments
@@ -90,7 +95,11 @@ class ReturnnRasrDataInput:
         self.features = features
         self.acoustic_mixtures = acoustic_mixtures
         self.feature_scorers = feature_scorers
+        self.shuffle_data = shuffle_data
         self.shuffling_parameters = shuffling_parameters
+        if shuffle_data and self.shuffling_parameters is None:
+            # apply the legacy defaults if shuffling_parameters is not set
+            self.shuffling_parameters = {"segment_order_sort_by_time_length_chunk_size": 384}
         self.stm = stm
         self.glm = glm
         self.returnn_rasr_training_args = returnn_rasr_training_args or ReturnnRasrTrainingArgs()
@@ -170,13 +179,14 @@ class ReturnnRasrDataInput:
         self.crp = crp
 
     def update_crp_with_shuffle_parameters(self):
-        if self.shuffling_parameters["shuffle_data"]:
+        if self.shuffle_data:
             self.crp.corpus_config.segment_order_shuffle = True
-        if "segment_order_sort_by_time_length_chunk_size" in self.shuffling_parameters:
-            self.crp.corpus_config.segment_order_sort_by_time_length = True
-            self.crp.corpus_config.segment_order_sort_by_time_length_chunk_size = self.shuffling_parameters[
-                "segment_order_sort_by_time_length_chunk_size"
-            ]
+        if self.shuffling_parameters is not None:
+            if "segment_order_sort_by_time_length_chunk_size" in self.shuffling_parameters:
+                self.crp.corpus_config.segment_order_sort_by_time_length = True
+                self.crp.corpus_config.segment_order_sort_by_time_length_chunk_size = self.shuffling_parameters[
+                    "segment_order_sort_by_time_length_chunk_size"
+                ]
 
     def update_crp_with(
         self,
@@ -186,7 +196,8 @@ class ReturnnRasrDataInput:
         corpus_duration: Optional[int] = None,
         segment_path: Optional[Union[str, tk.Path]] = None,
         concurrent: Optional[int] = None,
-        shuffling_paramters: Dict = None,
+        shuffle_data: Optional[bool] = None,
+        shuffling_parameters: Optional[Dict[str, Any]] = None,
     ):
         if corpus_file is not None:
             self.crp.corpus_config.file = corpus_file
@@ -198,11 +209,11 @@ class ReturnnRasrDataInput:
             self.crp.segment_path = segment_path
         if concurrent is not None:
             self.crp.concurrent = concurrent
-        if self.shuffling_parameters is not None:
-            assert (
-                "shuffle_data" in self.shuffle_parameters or "shuffle_data" in shuffle_parameters
-            ), "You need to set at least the shuffle_data"
-            self.shuffling_parameters = shuffling_paramters
+        if shuffle_data is not None:
+            self.shuffle_data = shuffle_data
+        if shuffling_parameters is not None:
+            assert self.shuffle_data, "You need to set shuffle_data to true when using shuffling_parameters"
+            self.shuffling_parameters = shuffling_parameters
             self.update_crp_with_shuffle_parameters()
 
     def get_crp(self, **kwargs) -> rasr.CommonRasrParameters:
@@ -213,7 +224,7 @@ class ReturnnRasrDataInput:
         if self.crp is None:
             self.build_crp(**kwargs)
 
-        if self.shuffling_parameters is not None:
+        if self.shuffle_data:
             self.update_crp_with_shuffle_parameters()
 
         return self.crp


### PR DESCRIPTION
I apologize again for my very insufficient review for https://github.com/rwth-i6/i6_experiments/pull/136, here are now the fixes.

 - Re-introduce legacy behavior (fixing the hashes)
 - Define separate `shuffle_data` and `shuffling_parameters` options
 - Rework documentation
 - Small fixes