### PR TITLE
ModelConfiguration serialization function

### DIFF
--- a/common/setups/returnn_pytorch/serialization.py
+++ b/common/setups/returnn_pytorch/serialization.py
@@ -1,18 +1,22 @@
 from __future__ import annotations
-from typing import Any, Dict, List, Optional, Set, Union
+
 import os
 import pathlib
 import shutil
 import string
 import textwrap
+from dataclasses import fields
+from inspect import isfunction
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
-from sisyphus import gs, tk
-from sisyphus.hash import sis_hash_helper
-from sisyphus.delayed_ops import DelayedBase
-
+import torch
 from i6_core.util import instanciate_delayed
+from i6_models.config import ModelConfiguration, ModuleFactoryV1
+from sisyphus import gs, tk
+from sisyphus.delayed_ops import DelayedBase
+from sisyphus.hash import sis_hash_helper
 
-from ..serialization import SerializerObject
+from ..serialization import Call, Import, SerializerObject
 
 
 class PyTorchModel(SerializerObject):
@@ -137,3 +141,106 @@ class Collection(DelayedBase):
             "delayed_objects": [obj for obj in self.serializer_objects if obj.use_for_hash],
         }
         return sis_hash_helper(h)
+
+
+def build_config_constructor_serializers(
+    cfg: ModelConfiguration, variable_name: Optional[str] = None, unhashed_package_root: Optional[str] = None
+) -> Tuple[Call, List[Import]]:
+    """
+    Creates a Call object that will re-construct the given ModelConfiguration when serialized and
+    optionally assigns the resulting config object to a variable. Automatically generates a list of all
+    necessary imports in order to perform the constructor call.
+
+    :param cfg: ModelConfiguration object that will be re-constructed by the Call serializer
+    :param variable_name: Name of the variable which the constructed ModelConfiguration
+                          will be assigned to. If None, the result will not be assigned
+                          to a variable.
+    :param unhashed_package_root: Will be passed to all generated Import objects.
+    :return: Call object and list of necessary imports.
+    """
+
+    # Import the class of <cfg>
+    imports = [
+        Import(
+            code_object_path=f"{type(cfg).__module__}.{type(cfg).__name__}", unhashed_package_root=unhashed_package_root
+        )
+    ]
+
+    call_kwargs = []
+
+    # Iterate over all dataclass fields
+    for key in fields(type(cfg)):
+        # Value corresponding to dataclass field name
+        value = getattr(cfg, key.name)
+
+        # Switch over serialization logic for different subtypes
+        if isinstance(value, ModelConfiguration):
+            # Example:
+            # ConformerBlockConfig(mhsa_config=ConformerMHSAConfig(...))
+            # -> Sub-Constructor-Call and imports for ConformerMHSAConfig
+            subcall, subimports = build_config_constructor_serializers(value)
+            imports += subimports
+            call_kwargs.append((key.name, subcall))
+        elif isinstance(value, ModuleFactoryV1):
+            # Example:
+            # ConformerEncoderConfig(
+            #     frontend=ModuleFactoryV1(module_class=VGGFrontend, cfg=VGGFrontendConfig(...)))
+            # -> Import classes ModuleFactoryV1, VGGFrontend and VGGFrontendConfig
+            # -> Sub-Constructor-Call for VGGFrontendConfig
+            subcall, subimports = build_config_constructor_serializers(value.cfg)
+            imports.append(
+                Import(
+                    code_object_path=f"{value.module_class.__module__}.{value.module_class.__name__}",
+                    unhashed_package_root=unhashed_package_root,
+                )
+            )
+            imports.append(
+                Import(
+                    code_object_path=f"{ModuleFactoryV1.__module__}.{ModuleFactoryV1.__name__}",
+                    unhashed_package_root=unhashed_package_root,
+                )
+            )
+            call_kwargs.append(
+                (
+                    key.name,
+                    Call(
+                        callable_name=ModuleFactoryV1.__name__,
+                        kwargs=[("module_class", value.module_class.__name__), ("cfg", subcall)],
+                    ),
+                )
+            )
+        elif isinstance(value, torch.nn.Module):
+            # Example:
+            # ConformerConvolutionConfig(norm=BatchNorm1d(...))
+            # -> Import class BatchNorm1d
+            # -> Sub-serialization of BatchNorm1d object.
+            #       The __str__ function of torch.nn.Module already does this in the way we want.
+            imports.append(
+                Import(
+                    code_object_path=f"{value.__module__}.{type(value).__name__}",
+                    unhashed_package_root=unhashed_package_root,
+                )
+            )
+            call_kwargs.append((key.name, str(value)))
+        elif isfunction(value):
+            # Example:
+            # ConformerConvolutionConfig(activation=torch.nn.functional.silu)
+            # -> Import function silu
+            # Builtins (e.g. 'sum') do not need to be imported
+            if value.__module__ != "builtins":
+                imports.append(
+                    Import(
+                        code_object_path=f"{value.__module__}.{value.__name__}",
+                        unhashed_package_root=unhashed_package_root,
+                    )
+                )
+            call_kwargs.append((key.name, value.__name__))
+        elif isinstance(value, DelayedBase):
+            # sisyphus variables are just given as-is and will be instanciated only when calling "get".
+            call_kwargs.append((key.name, value))
+        else:
+            # No special case (usually python primitives)
+            # -> Just get string representation
+            call_kwargs.append((key.name, str(value)))
+
+    return Call(callable_name=type(cfg).__name__, kwargs=call_kwargs, return_assign_variables=variable_name), imports


### PR DESCRIPTION
This is my current logic for serializing `ModelConfiguration` objects which are used for configuration of models in [i6_models](https://github.com/rwth-i6/i6_models). There are two main components in this PR:

1. A `Call` serializer object that simply serializes the call of a callable with given args/kwargs.
2. A function `build_config_constructor_serializers` that returns such a `Call` object in order to perform a constructor call that re-constructs a given `ModelConfiguration` object. Along the way it also identifies and returns all necessary imports.

As such, no manual `Import` specifications are necessary for the model config and there is no conversion from/to dictionaries happening.

The implementation at the moment supports the following range of value-types inside the `ModelConfiguration`:

- Other `ModelConfiguration` objects (nesting)
- `ModuleFactoryV1` objects
- `torch.nn.Module` objects
- Functions (e.g. `torch.nn.functional.silu` or `sum`)
- Sisyphus `DelayedBase` objects
- Python primitives

The PR also includes a change in the `Import` serializer object which adds a `unhashed_package_root` parameter and is mostly copied from @JackTemaki.

When building the ReturnnConfig object inside sisyphus the logic might look roughly something like this:
```
serializer_objects = [...]

model_import = Import("i6_experiments.users.berger.pytorch.models.conformer_ctc.ConformerCTCModel")
serializer_objects.append(model_import)

model_config = ConformerCTCConfig(conformer_cfg=ConformerEncoderV1Config(num_layers=12, ...), ...)
call, imports = build_config_constructor_serializers(model_config, "cfg")
serializer_objects.extend([*imports, call])
serializer_objects.append(
    PyTorchModel(model_class_name=model_import.object_name, model_kwargs: {"cfg": CodeWrapper("cfg")}
)
...
returnn_config = ReturnnConfig(..., python_epilog=Collection(serializer_objects))
```
After serialization this results in the following code inside the `returnn.config` file:
```
...
from i6_experiments.users.berger.pytorch.models.conformer_ctc import ConformerCTCModel
from i6_experiments.users.berger.pytorch.models.conformer_ctc import ConformerCTCConfig
from i6_models.assemblies.conformer.conformer_v1 import ConformerEncoderV1Config
...
cfg = ConformerCTCConfig(
    conformer_cfg=ConformerEncoderV1Config(
        num_layers=12,
...
)
model_kwargs = {"cfg": cfg}

def get_model(epoch, step, **kwargs):
    return ConformerCTCModel(epoch=epoch, step=step, **model_kwargs, **kwargs)
```