### PR TITLE
OnnxPrecomputedHybridSystem: recog at best epoch

### DIFF
--- a/common/setups/rasr/onnx_precomputed_hybrid_system.py
+++ b/common/setups/rasr/onnx_precomputed_hybrid_system.py
@@ -39,6 +39,7 @@ class OnnxPrecomputedHybridSystem(HybridSystem):
         train_job: Optional[Union[returnn.ReturnnTrainingJob, returnn.ReturnnRasrTrainingJob]] = None,
         needs_features_size: bool = True,
         acoustic_mixture_path: Optional[tk.Path] = None,
+        best_checkpoint_key: str = "dev_loss_CE",
         **kwargs,
     ):
         """
@@ -60,7 +61,7 @@ class OnnxPrecomputedHybridSystem(HybridSystem):
                 if epoch == "best":
                     assert train_job is not None, "train_job needed to get best epoch checkpoint"
                     best_checkpoint_job = GetBestPtCheckpointJob(
-                        train_job.out_model_dir, train_job.out_learning_rates, key="dev_loss_CE", index=0
+                        train_job.out_model_dir, train_job.out_learning_rates, key=best_checkpoint_key, index=0
                     )
                     checkpoint = best_checkpoint_job.out_checkpoint
                     epoch_str = epoch

--- a/common/setups/rasr/onnx_precomputed_hybrid_system.py
+++ b/common/setups/rasr/onnx_precomputed_hybrid_system.py
@@ -35,7 +35,7 @@ class OnnxPrecomputedHybridSystem(HybridSystem):
         rtf: int,
         mem: int,
         nn_prior: bool,
-        epochs: Optional[List[int]] = None,
+        epochs: Optional[List[int, str]] = None,
         train_job: Optional[Union[returnn.ReturnnTrainingJob, returnn.ReturnnRasrTrainingJob]] = None,
         needs_features_size: bool = True,
         acoustic_mixture_path: Optional[tk.Path] = None,


### PR DESCRIPTION
This PR adds support to allow specifying `"best"` as epoch for the recognition using the `OnnxPrecomputedHybridSystem`. It will use the `GetBestPtCheckpointJob` and the resulting output checkpoint.