### PR TITLE
add local norm to ExternalLMDecoder

### DIFF
--- a/users/zeineldeen/models/lm/external_lm_decoder.py
+++ b/users/zeineldeen/models/lm/external_lm_decoder.py
@@ -369,7 +369,7 @@ class ExternalLMDecoder:
       fusion_source += [ilm_decoder.output_prob_name]
 
     if self.ext_lm_opts.get("local_norm", False):
-      fusion_str = fusion_str + '- tf.math.reduce_logsumexp(' + fusion_str + ", axis=-1, keepdims=True)"
+      fusion_str = f"{fusion_str} - tf.math.reduce_logsumexp({fusion_str}, axis=-1, keepdims=True)"
 
     lm_net_out.add_eval_layer('combo_output_prob', source=fusion_source, eval=fusion_str)
     if self.length_normalization:


### PR DESCRIPTION
this adds the keys `"am_scale"` (default None) and `"local_norm"` (default False) to `ext_lm_opts`.

If `local_norm` is activated, it will locally norm over AM, LM and prior/iLM (if given)