### PR TITLE
generalize jobs for fairseq labeled data

### DIFF
--- a/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
+++ b/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
@@ -20,6 +20,25 @@ from recipe.i6_experiments.users.vieting.experiments.librispeech.librispeech_960
     import SetupFairseqJob
 
 
+def get_labels(
+    dest_name: str,
+    corpus_paths: Union[List[tk.Path], tk.Path],
+):
+    """
+    :param dest_name: name of the output file
+    :param corpus_paths: path to the corpora
+    """
+    if isinstance(corpus_paths, tk.Path):
+        corpus_paths = [corpus_paths]
+
+    label_data_job = CreateFairseqLabeledDataJob(
+        corpus_paths=corpus_paths,
+        dest_name=dest_name,
+    )
+    
+    return label_data_job.out_labels_path
+
+
 def get_task_dev_sampled(
     corpus_name: str,
     valid_percent: float = 0.01, 
@@ -141,23 +160,6 @@ def get_task_dev_separate(
     task = merge_job.out_task_path
     return task
 
-def get_labels(
-    dest_name: str,
-    corpus_paths: Union[List[tk.Path], tk.Path],
-):
-    """
-    :param dest_name: name of the output file
-    :param corpus_paths: path to the corpora
-    """
-    if isinstance(corpus_paths, tk.Path):
-        corpus_paths = [corpus_paths]
-
-    label_data_job = CreateFairseqLabeledDataJob(
-        corpus_paths=corpus_paths,
-        dest_name=dest_name,
-    )
-    
-    return label_data_job.out_labels_path
 
 def get_fairseq_root(fairseq_python_exe: Optional[tk.Path] = None):
     """

--- a/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
+++ b/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
@@ -271,34 +271,34 @@ def get_pretrained_model(model_path: Optional[Union[str, tk.Path]] = None):
 
 def main():
     # defines
-    PREFIX_NAME = "experiments/librispeech/librispeech_100_ctc/fairseq/"
-    EXP_NAME = "base"
-    NUM_GPUS = 1
-    GPU_MEM_RQMT = 24
-    CORPUS_NAME = "train-clean-100"
-    FAIRSEQ_PYTHON_EXE = tk.Path("/work/asr3/vieting/hiwis/pletschko/miniconda3/envs/fairseq_python38/bin/python")
-    USE_SAMPLED_DEV = False
+    prefix_name = "experiments/librispeech/librispeech_100_ctc/fairseq/"
+    exp_name = "base"
+    num_gpus = 1
+    gpu_mem_rqmt = 24
+    corpus_name = "train-clean-100"
+    fairseq_python_exe = tk.Path("/work/asr3/vieting/hiwis/pletschko/miniconda3/envs/fairseq_python38/bin/python")
+    use_sampled_dev = False
 
     # get pretrained model
     w2v_path = get_pretrained_model()
 
     # create wav2vec labeled data
-    if USE_SAMPLED_DEV:
+    if use_sampled_dev:
         dev_set = "dev"
-        labeled_data = get_task_dev_sampled(corpus_name=CORPUS_NAME, valid_percent=0.01)
+        labeled_data = get_task_dev_sampled(corpus_name=corpus_name, valid_percent=0.01)
     else:
         dev_set = "dev-other"
-        labeled_data = get_task_dev_separate(train_corpus_name=CORPUS_NAME, dev_corpus_name=dev_set)
+        labeled_data = get_task_dev_separate(train_corpus_name=corpus_name, dev_corpus_name=dev_set)
 
     # create fairseq config for finetuning
     fairseq_args = get_fairseq_args(
         labeled_data=labeled_data,
         w2v_path=w2v_path,
         dev_file_name=dev_set,
-        num_gpus=NUM_GPUS,
+        num_gpus=num_gpus,
     )
     fairseq_config = FairseqHydraConfig(fairseq_args)
-    fairseq_root = get_fairseq_root(fairseq_python_exe=FAIRSEQ_PYTHON_EXE)
+    fairseq_root = get_fairseq_root(fairseq_python_exe=fairseq_python_exe)
 
     # run finetuning
     job = FairseqHydraTrainingJob(
@@ -308,14 +308,14 @@ def main():
         time_rqmt=100,
         mem_rqmt=16,
         cpu_rqmt=2,
-        gpu_rqmt=NUM_GPUS,
-        gpu_mem_rqmt=GPU_MEM_RQMT,
+        gpu_rqmt=num_gpus,
+        gpu_mem_rqmt=gpu_mem_rqmt,
         fairseq_root=fairseq_root,
-        fairseq_python_exe=FAIRSEQ_PYTHON_EXE,
+        fairseq_python_exe=fairseq_python_exe,
         use_cache_manager=False,
     )
     
-    job.add_alias(os.path.join(PREFIX_NAME, EXP_NAME, "finetune"))
-    tk.register_output(os.path.join(PREFIX_NAME, EXP_NAME, "finetune", "scores.png"), job.out_plot_se)
+    job.add_alias(os.path.join(prefix_name, exp_name, "finetune"))
+    tk.register_output(os.path.join(prefix_name, exp_name, "finetune", "scores.png"), job.out_plot_se)
 
 main()

--- a/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
+++ b/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
@@ -156,7 +156,6 @@ def get_task_dev_separate(
         labeled_data_paths=[train_labels, dev_labels],
         create_letter_dict=True,
     )
-    merge_job.rqmt["time"] = 4
     task = merge_job.out_task_path
     return task
 

--- a/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
+++ b/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
@@ -44,9 +44,6 @@ def get_task(
          "test-other"}
     ), f"unknown corpus names: {corpus_names}"
 
-    if valid_percent <= 0:
-        logging.info("Not sampling validation set from training data. Create a separate dev set instead.")
-
     corpus_dict = get_bliss_corpus_dict(audio_format=audio_format, output_prefix=output_prefix)
     # filter out corpora that are not in corpus_names
     corpus_dict = {corpus: path for corpus, path in corpus_dict.items() if corpus in corpus_names}

--- a/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
+++ b/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
@@ -90,39 +90,39 @@ def get_task_dev_sampled(
     return task
 
 def get_task_dev_separate(
-    train_corpus_names: List[str],
+    train_corpus_name: str,
     dev_corpus_name: str,
     audio_format: str = "ogg",
     output_prefix: str = "datasets",
 ):
     """
-    :param train_corpus_names: list of names of the corpora to be used for training set
+    :param train_corpus_name: name of the corpus to be used for training set
     :param dev_corpus_name: name of the corpus to be used for validation set
     :param audio_format: audio format of the output files
     :param output_prefix: prefix of the output files
     """
     assert audio_format in ["ogg", "wav", "flac"], f"audio format not implemented: '{audio_format}'"
-    assert set(train_corpus_names).issubset(
-        {"train-clean-100", 
-         "train-clean-360", 
-         "train-clean-460", 
-         "train-other-500", 
-         "train-other-960", 
-         "dev-clean", 
-         "dev-other", 
-         "test-clean", 
-         "test-other"}
-    ), f"unknown corpus names: {train_corpus_names}"
+    assert train_corpus_name in {
+        "train-clean-100", 
+        "train-clean-360", 
+        "train-clean-460", 
+        "train-other-500", 
+        "train-other-960",
+        "dev-clean",
+        "dev-other",
+        "test-clean",
+        "test-other",
+        }, f"unknown train corpus name: {train_corpus_name}"
 
-    assert dev_corpus_name in {"dev-clean", "dev-other"}, f"unknown corpus name: {dev_corpus_name}"
+    assert dev_corpus_name in {"dev-clean", "dev-other"}, f"unknown dev corpus name: {dev_corpus_name}"
 
     corpus_dict = get_bliss_corpus_dict(audio_format=audio_format, output_prefix=output_prefix)
-    train_corpus_paths = [corpus_dict[name] for name in train_corpus_names]
+    train_corpus_path = corpus_dict[train_corpus_name]
     dev_corpus_path = corpus_dict[dev_corpus_name]
 
     train_labels = get_labels(
         dest_name="train",
-        corpus_paths=train_corpus_paths,
+        corpus_paths=train_corpus_path,
     )
     dev_labels = get_labels(
         dest_name=dev_corpus_name,
@@ -270,7 +270,7 @@ def main():
     EXP_NAME = "base"
     NUM_GPUS = 1
     GPU_MEM_RQMT = 24
-    CORPUS_NAMES = ["train-clean-100"]
+    CORPUS_NAME = "train-clean-100"
     FAIRSEQ_PYTHON_EXE = tk.Path("/work/asr3/vieting/hiwis/pletschko/miniconda3/envs/fairseq_python38/bin/python")
     USE_SAMPLED_DEV = False
 
@@ -280,10 +280,10 @@ def main():
     # create wav2vec labeled data
     if USE_SAMPLED_DEV:
         dev_set = "dev"
-        labeled_data = get_task_dev_sampled(corpus_name=CORPUS_NAMES[0], valid_percent=0.01)
+        labeled_data = get_task_dev_sampled(corpus_name=CORPUS_NAME, valid_percent=0.01)
     else:
         dev_set = "dev-other"
-        labeled_data = get_task_dev_separate(train_corpus_names=CORPUS_NAMES, dev_corpus_name=dev_set)
+        labeled_data = get_task_dev_separate(train_corpus_name=CORPUS_NAME, dev_corpus_name=dev_set)
 
     # create fairseq config for finetuning
     fairseq_args = get_fairseq_args(

--- a/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
+++ b/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
@@ -62,7 +62,7 @@ def get_task_dev_sampled(
         segment_file=shuffle_job.out_segments["train"], 
         compressed=True,
         delete_empty_recordings=True
-        )
+    )
     dev_filter_corpus_job = FilterCorpusBySegmentsJob(
         bliss_corpus=corpus_path,
         segment_file=shuffle_job.out_segments["dev"],

--- a/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
+++ b/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
@@ -6,6 +6,8 @@ from typing import List, Optional, Union
 
 import logging
 
+import logging
+
 from sisyphus import tk, gs
 import recipe.i6_core.datasets.librispeech as librispeech
 from recipe.i6_core.audio.encoding import BlissChangeEncodingJob

--- a/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
+++ b/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
@@ -2,7 +2,7 @@
 Config for finetune experiments on LibriSpeech using wav2vec 2.0.
 """
 import os.path
-from typing import List, Optional
+from typing import List, Optional, Union
 
 import logging
 

--- a/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
+++ b/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
@@ -55,7 +55,10 @@ def get_task_dev_sampled(
     segment_corpus_job = SegmentCorpusJob(corpus_path, 1)
 
     split = {"train": 1 - valid_percent, "dev": valid_percent}
-    shuffle_job = ShuffleAndSplitSegmentsJob(segment_corpus_job.out_single_segment_files[1])
+    shuffle_job = ShuffleAndSplitSegmentsJob(
+        segment_file = segment_corpus_job.out_single_segment_files[1],
+        split=split,
+    )   
 
     train_filter_corpus_job = FilterCorpusBySegmentsJob(
         bliss_corpus=corpus_path,

--- a/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
+++ b/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
@@ -68,7 +68,7 @@ def get_task_dev_sampled(
         segment_file=shuffle_job.out_segments["dev"],
         compressed=True,
         delete_empty_recordings=True
-        )    
+    )
 
     # create labeled data for training and dev set
     train_labels = get_labels(

--- a/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
+++ b/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
@@ -2,7 +2,7 @@
 Config for finetune experiments on LibriSpeech using wav2vec 2.0.
 """
 import os.path
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Dict
 
 import logging
 
@@ -11,28 +11,98 @@ import recipe.i6_core.datasets.librispeech as librispeech
 from recipe.i6_core.audio.encoding import BlissChangeEncodingJob
 from recipe.i6_core.tools.git import CloneGitRepositoryJob
 from recipe.i6_core.tools.download import DownloadJob 
+from recipe.i6_core.corpus.segments import ShuffleAndSplitSegmentsJob, SegmentCorpusJob
+from recipe.i6_core.corpus.filter import FilterCorpusBySegmentsJob
 from recipe.i6_experiments.common.datasets.librispeech.corpus import get_bliss_corpus_dict
 from recipe.i6_experiments.users.engler.fairseq.training import FairseqHydraConfig, FairseqHydraTrainingJob
-from recipe.i6_experiments.users.vieting.jobs.fairseq import CreateFairseqLabeledDataJob
+from recipe.i6_experiments.users.vieting.jobs.fairseq import CreateFairseqLabeledDataJob, MergeLabeledFairseqDataJob
 from recipe.i6_experiments.users.vieting.experiments.librispeech.librispeech_960_pretraining.wav2vec2.fairseq \
     import SetupFairseqJob
 
 
-def get_task(
+def get_task_dev_sampled(
+    corpus_name: str,
     valid_percent: float = 0.01, 
     audio_format: str = "ogg", 
-    output_prefix: str = "datasets", 
-    corpus_names: List[str] = ["train-clean-100", "train-clean-360", "train-other-500"]
+    output_prefix: str = "datasets",
 ):
     """
+    :param corpus_name: name of the corpora to be used for training and to sample the dev set from
     :param valid_percent: percentage of the training data to be used as validation set. 
-        If <= 0, the validation set is taken from the dev corpus.
     :param audio_format: audio format of the output files
     :param output_prefix: prefix of the output files
-    :param corpus_names: list of names of the corpora to be used for training
+    """
+    # check input
+    assert audio_format in ["ogg", "wav", "flac"], f"audio format not implemented: '{audio_format}'"
+    assert corpus_name in {
+        "train-clean-100", 
+        "train-clean-360", 
+        "train-clean-460", 
+        "train-other-500", 
+        "train-other-960",
+        "dev-clean",
+        "dev-other",
+        "test-clean",
+        "test-other",
+        }, f"unknown corpus name: {corpus_name}"
+    assert 0 <= valid_percent <= 1, f"invalid percentage: {valid_percent}"
+
+    # get corpus
+    corpus_dict = get_bliss_corpus_dict(audio_format=audio_format, output_prefix=output_prefix)
+    corpus_path = corpus_dict[corpus_name]
+
+    # split corpus into train and dev set
+    segment_corpus_job = SegmentCorpusJob(corpus_path, 1)
+
+    split = {"train": 1 - valid_percent, "dev": valid_percent}
+    shuffle_job = ShuffleAndSplitSegmentsJob(segment_corpus_job.out_single_segment_files[1])
+
+    train_filter_corpus_job = FilterCorpusBySegmentsJob(
+        bliss_corpus=corpus_path,
+        segment_file=shuffle_job.out_segments["train"], 
+        compressed=True,
+        delete_empty_recordings=True
+        )
+    dev_filter_corpus_job = FilterCorpusBySegmentsJob(
+        bliss_corpus=corpus_path,
+        segment_file=shuffle_job.out_segments["dev"],
+        compressed=True,
+        delete_empty_recordings=True
+        )    
+
+    # create labeled data for training and dev set
+    train_labels = get_labels(
+        dest_name="train",
+        corpus_paths=train_filter_corpus_job.out_corpus,
+    )
+    dev_labels = get_labels(
+        dest_name="dev",
+        corpus_paths=dev_filter_corpus_job.out_corpus,
+    )
+
+    # merge labeled data into single task directory
+    merge_job = MergeLabeledFairseqDataJob(
+        labeled_data_paths=[train_labels, dev_labels],
+        create_letter_dict=True,
+    )
+
+    task = merge_job.out_task_path
+    return task
+
+def get_task_dev_separate(
+    train_corpus_names: List[str],
+    dev_corpus_name: str,
+    audio_format: str = "ogg",
+    output_prefix: str = "datasets",
+):
+    """
+    :param train_corpus_names: list of names of the corpora to be used for training set
+    :param dev_corpus_name: name of the corpus to be used for validation set
+    :param audio_format: audio format of the output files
+    :param output_prefix: prefix of the output files
     """
     assert audio_format in ["ogg", "wav", "flac"], f"audio format not implemented: '{audio_format}'"
-    assert set(corpus_names).issubset(
+    assert set(train_corpus_names).issubset(
         {"train-clean-100", 
          "train-clean-360", 
          "train-clean-460", 
@@ -42,23 +112,49 @@ def get_task(
          "dev-other", 
          "test-clean", 
          "test-other"}
-    ), f"unknown corpus names: {corpus_names}"
+    ), f"unknown corpus names: {train_corpus_names}"
+
+    assert dev_corpus_name in {"dev-clean", "dev-other"}, f"unknown corpus name: {dev_corpus_name}"
 
     corpus_dict = get_bliss_corpus_dict(audio_format=audio_format, output_prefix=output_prefix)
-    # filter out corpora that are not in corpus_names
-    corpus_dict = {corpus: path for corpus, path in corpus_dict.items() if corpus in corpus_names}
+    train_corpus_paths = [corpus_dict[name] for name in train_corpus_names]
+    dev_corpus_path = corpus_dict[dev_corpus_name]
 
-    task_creation_job = CreateFairseqLabeledDataJob(
-        train_corpus_paths=list(corpus_dict.values()),
-        file_extension=audio_format,
-        sample_valid_percent=valid_percent,
-        train_dest_name="train",
-        valid_dest_name="valid",
+    train_labels = get_labels(
+        dest_name="train",
+        corpus_paths=train_corpus_paths,
+    )
+    dev_labels = get_labels(
+        dest_name=dev_corpus_name,
+        corpus_paths=dev_corpus_path,
+    )
+
+    merge_job = MergeLabeledFairseqDataJob(
+        labeled_data_paths=[train_labels, dev_labels],
         create_letter_dict=True,
     )
-    task_creation_job.rqmt["time"] = 4
-    task = task_creation_job.out_task_path
+    merge_job.rqmt["time"] = 4
+    task = merge_job.out_task_path
     return task
+
+def get_labels(
+    dest_name: str,
+    corpus_paths: Union[List[tk.Path], tk.Path],
+):
+    """
+    :param dest_name: name of the output file
+    :param corpus_paths: path to the corpora
+    """
+    if isinstance(corpus_paths, tk.Path):
+        corpus_paths = [corpus_paths]
+
+    label_data_job = CreateFairseqLabeledDataJob(
+        corpus_paths=corpus_paths,
+        dest_name=dest_name,
+    )
+    label_data_job.rqmt["time"] = 4
+    
+    return label_data_job.out_labels_path
 
 def get_fairseq_root(fairseq_python_exe: Optional[tk.Path] = None):
     """
@@ -72,15 +168,26 @@ def get_fairseq_root(fairseq_python_exe: Optional[tk.Path] = None):
     return fairseq_root
 
 
-def get_fairseq_args(w2v_path: tk.Path, corpus_names: List[str], num_gpus: int = 1):
+def get_fairseq_args(
+    labeled_data: tk.Path, 
+    w2v_path: tk.Path, 
+    dev_file_name: str = "dev", 
+    num_gpus: int = 1
+    ):
     """
+    :param labeled_data: path to the labeled data including the following files:
+        - train.tsv
+        - train.wrd
+        - train.ltr
+        - <dev_file_name>.tsv
+        - <dev_file_name>.wrd
+        - <dev_file_name>.ltr
+        - letter_dict.txt
+    :param dev_file_name: name of the dev label files
     :param w2v_path: path to the (pretrained) wav2vec model
     :param corpus_names: list of names of the corpora to be used for training
     :param num_gpus: number of gpus to be used for training
     """
-    # create wav2vec manifest for training
-    task = get_task(corpus_names=corpus_names)
-
     # Set training and model parameters
     fairseq_args = {
         "common": {
@@ -94,7 +201,7 @@ def get_fairseq_args(w2v_path: tk.Path, corpus_names: List[str], num_gpus: int =
         },
         "task": {
             "_name": "audio_finetuning",
-            "data": task,
+            "data": labeled_data,
             "normalize": False,
             "labels": "ltr"
         },
@@ -102,7 +209,7 @@ def get_fairseq_args(w2v_path: tk.Path, corpus_names: List[str], num_gpus: int =
             "num_workers": 2 * num_gpus,
             "max_tokens": 3200000,  # length of tokens in one batch
             "skip_invalid_size_inputs_valid_test": True,
-            "valid_subset": "valid",
+            "valid_subset": dev_file_name,
         },
         "distributed_training": {
             "distributed_world_size": num_gpus,
@@ -158,19 +265,37 @@ def get_pretrained_model(model_path: Optional[Union[str, tk.Path]] = None):
 
 
 def main():
-    prefix_name = "experiments/librispeech/librispeech_100_ctc/fairseq/"
-    # run finetuning
-    exp_name = "base"
-    num_gpus = 1
-    gpu_mem_rqmt = 24
-    corpus_names = ["train-clean-100"]
+    # defines
+    PREFIX_NAME = "experiments/librispeech/librispeech_100_ctc/fairseq/"
+    EXP_NAME = "base"
+    NUM_GPUS = 1
+    GPU_MEM_RQMT = 24
+    CORPUS_NAMES = ["train-clean-100"]
+    FAIRSEQ_PYTHON_EXE = tk.Path("/work/asr3/vieting/hiwis/pletschko/miniconda3/envs/fairseq_python38/bin/python")
+    USE_SAMPLED_DEV = False
 
+    # get pretrained model
     w2v_path = get_pretrained_model()
-    fairseq_python_exe = tk.Path("/work/asr3/vieting/hiwis/pletschko/miniconda3/envs/fairseq_python38/bin/python")
 
-    fairseq_args = get_fairseq_args(corpus_names=corpus_names, num_gpus=num_gpus, w2v_path=w2v_path)
+    # create wav2vec labeled data
+    if USE_SAMPLED_DEV:
+        dev_set = "dev"
+        labeled_data = get_task_dev_sampled(corpus_name=CORPUS_NAMES[0], valid_percent=0.01)
+    else:
+        dev_set = "dev-other"
+        labeled_data = get_task_dev_separate(train_corpus_names=CORPUS_NAMES, dev_corpus_name=dev_set)
+
+    # create fairseq config for finetuning
+    fairseq_args = get_fairseq_args(
+        labeled_data=labeled_data,
+        w2v_path=w2v_path,
+        dev_file_name=dev_set,
+        num_gpus=NUM_GPUS,
+    )
     fairseq_config = FairseqHydraConfig(fairseq_args)
-    fairseq_root = get_fairseq_root(fairseq_python_exe=fairseq_python_exe)
+    fairseq_root = get_fairseq_root(fairseq_python_exe=FAIRSEQ_PYTHON_EXE)
+
+    # run finetuning
     job = FairseqHydraTrainingJob(
         fairseq_config,
         max_epoch=300,
@@ -178,14 +303,14 @@ def main():
         time_rqmt=100,
         mem_rqmt=16,
         cpu_rqmt=2,
-        gpu_rqmt=num_gpus,
-        gpu_mem_rqmt=gpu_mem_rqmt,
+        gpu_rqmt=NUM_GPUS,
+        gpu_mem_rqmt=GPU_MEM_RQMT,
         fairseq_root=fairseq_root,
-        fairseq_python_exe=fairseq_python_exe,
-        use_cache_manager=True,
+        fairseq_python_exe=FAIRSEQ_PYTHON_EXE,
+        use_cache_manager=False,
     )
     
-    job.add_alias(os.path.join(prefix_name, exp_name, "finetune"))
-    tk.register_output(os.path.join(prefix_name, exp_name, "finetune", "scores.png"), job.out_plot_se)
+    job.add_alias(os.path.join(PREFIX_NAME, EXP_NAME, "finetune"))
+    tk.register_output(os.path.join(PREFIX_NAME, EXP_NAME, "finetune", "scores.png"), job.out_plot_se)
 
 main()

--- a/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
+++ b/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
@@ -112,7 +112,7 @@ def get_task_dev_separate(
         "dev-other",
         "test-clean",
         "test-other",
-        }, f"unknown train corpus name: {train_corpus_name}"
+    }, f"unknown train corpus name: {train_corpus_name}"
 
     assert dev_corpus_name in {"dev-clean", "dev-other"}, f"unknown dev corpus name: {dev_corpus_name}"
 

--- a/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
+++ b/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
@@ -52,11 +52,11 @@ def get_task(
     corpus_dict = {corpus: path for corpus, path in corpus_dict.items() if corpus in corpus_names}
 
     task_creation_job = CreateFairseqLabeledDataJob(
-        corpus_paths=list(corpus_dict.values()),
+        train_corpus_paths=list(corpus_dict.values()),
         file_extension=audio_format,
         sample_valid_percent=valid_percent,
-        dest_name="train",
-        sample_valid_name="valid",
+        train_dest_name="train",
+        valid_dest_name="valid",
         create_letter_dict=True,
     )
     task_creation_job.rqmt["time"] = 4

--- a/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
+++ b/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
@@ -44,7 +44,7 @@ def get_task_dev_sampled(
         "dev-other",
         "test-clean",
         "test-other",
-        }, f"unknown corpus name: {corpus_name}"
+    }, f"unknown corpus name: {corpus_name}"
     assert 0 <= valid_percent <= 1, f"invalid percentage: {valid_percent}"
 
     # get corpus

--- a/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
+++ b/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
@@ -153,7 +153,6 @@ def get_labels(
         corpus_paths=corpus_paths,
         dest_name=dest_name,
     )
-    label_data_job.rqmt["time"] = 4
     
     return label_data_job.out_labels_path
 

--- a/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
+++ b/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
@@ -89,6 +89,7 @@ def get_task_dev_sampled(
     task = merge_job.out_task_path
     return task
 
+
 def get_task_dev_separate(
     train_corpus_name: str,
     dev_corpus_name: str,

--- a/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
+++ b/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
@@ -6,8 +6,6 @@ from typing import List, Optional, Union
 
 import logging
 
-import logging
-
 from sisyphus import tk, gs
 import recipe.i6_core.datasets.librispeech as librispeech
 from recipe.i6_core.audio.encoding import BlissChangeEncodingJob

--- a/users/vieting/jobs/fairseq.py
+++ b/users/vieting/jobs/fairseq.py
@@ -164,6 +164,7 @@ class MergeLabeledFairseqDataJob(Job):
                 if file.endswith(".tsv") or file.endswith(".ltr") or file.endswith(".wrd"):
                     src = os.path.join(path.get(), file)
                     dst = os.path.join(self.out_task_path.get(), file)
+                    assert not os.path.exists(dst), f"'{dst}' exists, two inputs have the same names"
                     shutil.copyfile(src, dst)
                 else:
                     logging.warning(f"Ignoring File {filename}; is not a valid fairseq file.")

--- a/users/vieting/jobs/fairseq.py
+++ b/users/vieting/jobs/fairseq.py
@@ -119,13 +119,13 @@ class CreateFairseqLabeledDataJob(Job):
         train_common_dir, valid_common_dir = self.get_common_dir()
 
         valid_tsv = open(self.out_valid_tsv_path, "w")
-        train_tsv = open(self.out_train_tsv_path, "w")
+        dest_tsv = open(self.out_dest_tsv_path, "w")
 
         valid_ltr = open(self.out_valid_ltr_path, "w")
-        train_ltr = open(self.out_train_ltr_path, "w")
+        dest_ltr = open(self.out_dest_ltr_path, "w")
 
         valid_wrd = open(self.out_valid_wrd_path, "w") 
-        train_wrd = open(self.out_train_wrd_path, "w")
+        dest_wrd = open(self.out_dest_wrd_path, "w")
 
         # write common directory (root) to tsv files
         if self.valid_percent > 0:
@@ -149,9 +149,9 @@ class CreateFairseqLabeledDataJob(Job):
 
                 # determine whether to write to dest or valid
                 if rand.random() >= self.valid_percent:
-                    tsv_out = train_tsv
-                    ltr_out = train_ltr
-                    wrd_out = train_wrd
+                    tsv_out = dest_tsv
+                    ltr_out = dest_ltr
+                    wrd_out = dest_wrd
                 else:
                     tsv_out = valid_tsv
                     ltr_out = valid_ltr
@@ -197,9 +197,9 @@ class CreateFairseqLabeledDataJob(Job):
         valid_ltr.close()
         valid_wrd.close()
         
-        train_tsv.close()
-        train_ltr.close()
-        train_wrd.close()
+        dest_tsv.close()
+        dest_ltr.close()
+        dest_wrd.close()
 
 
 

--- a/users/vieting/jobs/fairseq.py
+++ b/users/vieting/jobs/fairseq.py
@@ -51,7 +51,7 @@ class CreateFairseqLabeledDataJob(Job):
         :param path_must_contain: if set, path must contain this substring
             for a file to be included in the task
         :param dest_name: name of the main label files. Default: "train"
-        :param sample_valid_name: name of the sampled validation label files. Default: "valid". Ignored if sample_valid_percent is 0.
+        :param create_letter_dict: if set to True, a dict.ltr.txt file will be created. Default: True
         : 
         """
         if not isinstance(corpus_paths, list):

--- a/users/vieting/jobs/fairseq.py
+++ b/users/vieting/jobs/fairseq.py
@@ -107,18 +107,15 @@ class CreateFairseqLabeledDataJob(Job):
         """
         Returns the common directory of all audios given in the corpora.
         """
-        common_dir = None
+        audio_paths = []
         # iterate over all corpora
         for corpus_path in self.corpus_paths:
             corpus_object = corpus.Corpus()
             corpus_object.load(corpus_path.get())
-            for segment in corpus_object.segments():
-                audio_path = segment.recording.audio
+            for recording in corpus_object.recordings():
+                audio_paths.append(recording.audio)
                 assert os.path.exists(audio_path), f"Path {audio_path} does not exist."
-                if common_dir is None:
-                    common_dir = os.path.dirname(audio_path)
-                else:
-                    common_dir = os.path.commonpath([common_dir, os.path.dirname(audio_path)])
+        common_dir = os.path.commonpath(audio_paths)
         return common_dir
 
 

--- a/users/vieting/jobs/fairseq.py
+++ b/users/vieting/jobs/fairseq.py
@@ -63,6 +63,7 @@ class CreateFairseqLabeledDataJob(Job):
         assert 0.0 <= self.valid_percent <= 1.0
         self.seed = seed
         self.path_must_contain = path_must_contain
+        self.create_letter_dict = create_letter_dict
 
         self.out_task_path = self.output_path("task", directory=True)
 

--- a/users/vieting/jobs/fairseq.py
+++ b/users/vieting/jobs/fairseq.py
@@ -146,7 +146,7 @@ class MergeLabeledFairseqDataJob(Job):
         self.out_dict_ltr_path = self.output_path("task/dict.ltr.txt")
 
     def tasks(self):
-        yield Task("run", rqmt=self.rqmt, mini_task=True)
+        yield Task("run", mini_task=True)
 
     def run(self):
         self.merge()

--- a/users/vieting/jobs/fairseq.py
+++ b/users/vieting/jobs/fairseq.py
@@ -18,16 +18,6 @@ class CreateFairseqLabeledDataJob(Job):
     - dest.ltr
     - dest.wrd
 
-    If create_letter_dict is set to True, the following file will be created:
-    - dict.ltr.txt
-
-    If sample_valid_percent is set > 0, a random sample of the files will be saved as validation set 
-    and the following files will be created:
-    - valid.tsv
-    - valid.ltr
-    - valid.wrd
-    
-
     For the script see https://github.com/pytorch/fairseq/blob/main/examples/wav2vec/wav2vec_manifest.py for .tsv creation,
     https://github.com/facebookresearch/fairseq/blob/91c364b7ceef8032099363cb10ba19a85b050c1c/examples/wav2vec/libri_labels.py 
     as well as the issue https://github.com/facebookresearch/fairseq/issues/2493 for .wrd and .ltr creation.
@@ -46,14 +36,9 @@ class CreateFairseqLabeledDataJob(Job):
         """
         :param corpus_paths: list of paths or single path to raw audio file directory to be included
         :param file_extension: file extension to look for in corpus_paths
-        :param sample_valid_percent: percentage of files to be randomly sampled as validation set
-        :param seed: random seed for splitting into train and valid set
         :param path_must_contain: if set, path must contain this substring
             for a file to be included in the task
         :param dest_name: name of the main label files. Default: "train"
-        :param sample_valid_name: name of the sampled validation label files. Default: "valid". 
-            Ignored if sample_valid_percent is 0.
-        :param create_letter_dict: if set to True, a dict.ltr.txt file will be created. Default: True
         """
         if not isinstance(corpus_paths, list):
             corpus_paths = [corpus_paths]
@@ -80,8 +65,7 @@ class CreateFairseqLabeledDataJob(Job):
 
     def create_tsv_and_labels(self):
         """
-        Creates both tsv files (train.tsv, valid.tsv) and labels (train.ltr, train.wrd, valid.ltr, valid.wrd) 
-        from the given corpora.
+        Creates both .tsv file and labels (.ltr and .wrd files) from the given corpora.
         """        
         common_dir = self.get_common_dir()
 
@@ -105,7 +89,7 @@ class CreateFairseqLabeledDataJob(Job):
                 rel_audio_path = os.path.relpath(audio_path, common_dir)
                 frames = soundfile.info(audio_path).frames
                 
-                # write audio path to tsv files
+                # write audio path to tsv file
                 print(f"{rel_audio_path}\t{frames}", file=tsv)
 
                 # write transcription to transcription files

--- a/users/vieting/jobs/fairseq.py
+++ b/users/vieting/jobs/fairseq.py
@@ -38,7 +38,7 @@ class CreateFairseqLabeledDataJob(Job):
     def __init__(
         self,
         train_corpus_paths: Union[List[tk.Path], tk.Path],
-        valid_corpus_paths: Union[List[tk.Path], tk.Path] = [],
+        valid_corpus_paths: Union[List[tk.Path], tk.Path] = None,
         file_extension: str = "wav",
         sample_valid_percent: float = 0.01,
         seed: int = 42,

--- a/users/vieting/jobs/fairseq.py
+++ b/users/vieting/jobs/fairseq.py
@@ -119,13 +119,13 @@ class CreateFairseqLabeledDataJob(Job):
         train_common_dir, valid_common_dir = self.get_common_dir()
 
         valid_tsv = open(self.out_valid_tsv_path, "w")
-        dest_tsv = open(self.out_dest_tsv_path, "w")
+        train_tsv = open(self.out_train_tsv_path, "w")
 
         valid_ltr = open(self.out_valid_ltr_path, "w")
-        dest_ltr = open(self.out_dest_ltr_path, "w")
+        train_ltr = open(self.out_train_ltr_path, "w")
 
         valid_wrd = open(self.out_valid_wrd_path, "w") 
-        dest_wrd = open(self.out_dest_wrd_path, "w")
+        train_wrd = open(self.out_train_wrd_path, "w")
 
         # write common directory (root) to tsv files
         if self.valid_percent > 0:
@@ -149,9 +149,9 @@ class CreateFairseqLabeledDataJob(Job):
 
                 # determine whether to write to dest or valid
                 if rand.random() >= self.valid_percent:
-                    tsv_out = dest_tsv
-                    ltr_out = dest_ltr
-                    wrd_out = dest_wrd
+                    tsv_out = train_tsv
+                    ltr_out = train_ltr
+                    wrd_out = train_wrd
                 else:
                     tsv_out = valid_tsv
                     ltr_out = valid_ltr
@@ -197,9 +197,9 @@ class CreateFairseqLabeledDataJob(Job):
         valid_ltr.close()
         valid_wrd.close()
         
-        dest_tsv.close()
-        dest_ltr.close()
-        dest_wrd.close()
+        train_tsv.close()
+        train_ltr.close()
+        train_wrd.close()
 
 
 

--- a/users/vieting/jobs/fairseq.py
+++ b/users/vieting/jobs/fairseq.py
@@ -64,9 +64,9 @@ class CreateFairseqLabeledDataJob(Job):
 
         self.out_labels_path = self.output_path("labels", directory=True)
 
-        self.out_dest_tsv_path = self.output_path(f"labels/{dest_name}.tsv")        
-        self.out_dest_ltr_path = self.output_path(f"labels/{dest_name}.ltr")
-        self.out_dest_wrd_path = self.output_path(f"labels/{dest_name}.wrd")
+        self.out_tsv_path = self.output_path(f"labels/{dest_name}.tsv")
+        self.out_ltr_path = self.output_path(f"labels/{dest_name}.ltr")
+        self.out_wrd_path = self.output_path(f"labels/{dest_name}.wrd")
 
         self.rqmt = {"time": 6, "mem": 8, "cpu": 1}
 
@@ -84,12 +84,12 @@ class CreateFairseqLabeledDataJob(Job):
         """        
         common_dir = self.get_common_dir()
 
-        dest_tsv = open(self.out_dest_tsv_path, "w")
-        dest_ltr = open(self.out_dest_ltr_path, "w")
-        dest_wrd = open(self.out_dest_wrd_path, "w")
+        tsv = open(self.out_tsv_path, "w")
+        ltr = open(self.out_ltr_path, "w")
+        wrd = open(self.out_wrd_path, "w")
 
         # write common directory (root) to tsv files
-        print(common_dir, file=dest_tsv)
+        print(common_dir, file=tsv)
 
         # iterate over all corpora
         for corpus_path in self.corpus_paths:
@@ -105,18 +105,18 @@ class CreateFairseqLabeledDataJob(Job):
                 frames = soundfile.info(audio_path).frames
                 
                 # write audio path to tsv files
-                print(f"{rel_audio_path}\t{frames}", file=dest_tsv)
+                print(f"{rel_audio_path}\t{frames}", file=tsv)
 
                 # write transcription to transcription files
                 print(
                     " ".join(list(audio_trans.replace(" ", "|"))) + " |",
-                    file=dest_ltr,
+                    file=ltr,
                 )
-                print(audio_trans, file=dest_wrd)
+                print(audio_trans, file=wrd)
 
-        dest_tsv.close()
-        dest_ltr.close()
-        dest_wrd.close()
+        tsv.close()
+        ltr.close()
+        wrd.close()
 
     def get_common_dir(self):
         """

--- a/users/vieting/jobs/fairseq.py
+++ b/users/vieting/jobs/fairseq.py
@@ -4,6 +4,7 @@ import os
 import random
 import subprocess
 from typing import List, Union, Optional 
+import logging
 
 from sisyphus import Job, Task, tk
 
@@ -36,50 +37,63 @@ class CreateFairseqLabeledDataJob(Job):
 
     def __init__(
         self,
-        corpus_paths: Union[List[tk.Path], tk.Path],
+        train_corpus_paths: Union[List[tk.Path], tk.Path],
+        valid_corpus_paths: Union[List[tk.Path], tk.Path] = [],
         file_extension: str = "wav",
         sample_valid_percent: float = 0.01,
         seed: int = 42,
         path_must_contain: Optional[str] = None,
-        dest_name: str = "train",
-        sample_valid_name: str = "valid",
+        train_dest_name: str = "train",
+        valid_dest_name: str = "valid",
         create_letter_dict: bool = True,
     ):
         """
-        :param corpus_paths: list of paths or single path to raw audio file directory to be included
+        :param corpus_paths: list of paths or single path to raw audio file directory to be included in training set
+        :param valid_corpus_paths: list of paths or single path to raw audio file directory to be included in 
+            validation set. Ignored if sample_valid_percent > 0. Default: []
         :param file_extension: file extension to look for in corpus_paths
-        :param sample_valid_percent: percentage of files to be randomly sampled as validation set
+        :param sample_valid_percent: percentage of files to be randomly sampled as validation set. 
+            If > 0, valid_corpus_paths will be ignored. Default: 0.01
         :param seed: random seed for splitting into train and valid set
         :param path_must_contain: if set, path must contain this substring
             for a file to be included in the task
-        :param dest_name: name of the main label files. Default: "train"
-        :param sample_valid_name: name of the sampled validation label files. Default: "valid". 
-            Ignored if sample_valid_percent is 0.
+        :param train_dest_name: name of the train label files. Default: "train"
+        :param valid_dest_name: name of the valid label files. Default: "valid"
         :param create_letter_dict: if set to True, a dict.ltr.txt file will be created. Default: True
         : 
         """
-        if not isinstance(corpus_paths, list):
-            corpus_paths = [corpus_paths]
-        self.corpus_paths = corpus_paths
-        assert all([isinstance(path, tk.Path) for path in self.corpus_paths])
+        if not isinstance(train_corpus_paths, list):
+            train_corpus_paths = [train_corpus_paths]
+        if not isinstance(valid_corpus_paths, list):
+            valid_corpus_paths = [valid_corpus_paths]
+    
+        self.train_corpus_paths = train_corpus_paths
+        self.valid_corpus_paths = valid_corpus_paths
+        assert all([isinstance(path, tk.Path) for path in self.train_corpus_paths])
+        assert all([isinstance(path, tk.Path) for path in self.valid_corpus_paths])
+
         self.file_extension = file_extension
         self.valid_percent = sample_valid_percent
-        assert 0.0 <= self.valid_percent <= 1.0
+        assert 0.0 <= self.valid_percent <= 1.0, "sample_valid_percent must be between 0 and 1."
         self.seed = seed
         self.path_must_contain = path_must_contain
         self.create_letter_dict = create_letter_dict
 
+        if not valid_corpus_paths and self.valid_percent == 0:
+            logging.warning("No validation set given and sample_valid_percent is 0. No validation set will be created.")
+
+
         self.out_task_path = self.output_path("task", directory=True)
 
-        self.out_dest_tsv_path = self.output_path(f"task/{dest_name}.tsv")
-        self.out_valid_tsv_path = self.output_path(f"task/{sample_valid_name}.tsv")
+        self.out_train_tsv_path = self.output_path(f"task/{train_dest_name}.tsv")
+        self.out_valid_tsv_path = self.output_path(f"task/{valid_dest_name}.tsv")
         
         self.out_dict_ltr_path = self.output_path("task/dict.ltr.txt")
 
-        self.out_dest_ltr_path = self.output_path(f"task/{dest_name}.ltr")
-        self.out_dest_wrd_path = self.output_path(f"task/{dest_name}.wrd")
-        self.out_valid_ltr_path = self.output_path(f"task/{sample_valid_name}.ltr")
-        self.out_valid_wrd_path = self.output_path(f"task/{sample_valid_name}.wrd")
+        self.out_train_ltr_path = self.output_path(f"task/{train_dest_name}.ltr")
+        self.out_train_wrd_path = self.output_path(f"task/{train_dest_name}.wrd")
+        self.out_valid_ltr_path = self.output_path(f"task/{valid_dest_name}.ltr")
+        self.out_valid_wrd_path = self.output_path(f"task/{valid_dest_name}.wrd")
 
         self.rqmt = {"time": 6, "mem": 8, "cpu": 1}
 
@@ -91,6 +105,9 @@ class CreateFairseqLabeledDataJob(Job):
         self.create_tsv_and_labels()
         if self.create_letter_dict:
             self.create_dict_ltr()
+        if self.valid_percent == 0 and not self.valid_corpus_paths:
+            self.delete_valid_files()
+        
 
     def create_tsv_and_labels(self):
         """
@@ -99,24 +116,26 @@ class CreateFairseqLabeledDataJob(Job):
         """
         rand = random.Random(self.seed)
         
-        common_dir = self.get_common_dir()
+        train_common_dir, valid_common_dir = self.get_common_dir()
 
         valid_tsv = open(self.out_valid_tsv_path, "w")
-        dest_tsv = open(self.out_dest_tsv_path, "w")
+        train_tsv = open(self.out_train_tsv_path, "w")
 
         valid_ltr = open(self.out_valid_ltr_path, "w")
-        dest_ltr = open(self.out_dest_ltr_path, "w")
+        train_ltr = open(self.out_train_ltr_path, "w")
 
         valid_wrd = open(self.out_valid_wrd_path, "w") 
-        dest_wrd = open(self.out_dest_wrd_path, "w")
+        train_wrd = open(self.out_train_wrd_path, "w")
 
         # write common directory (root) to tsv files
         if self.valid_percent > 0:
-            print(common_dir, file=valid_tsv)
-        print(common_dir, file=dest_tsv)
+            print(train_common_dir, file=valid_tsv)
+        elif self.valid_corpus_paths:
+            print(valid_common_dir, file=valid_tsv)
+        print(train_common_dir, file=train_tsv)
 
-        # iterate over all corpora
-        for corpus_path in self.corpus_paths:
+        # iterate over all training corpora
+        for corpus_path in self.train_corpus_paths:
             corpus_object = corpus.Corpus()
             corpus_object.load(corpus_path.get())
             for segment in corpus_object.segments():
@@ -125,14 +144,14 @@ class CreateFairseqLabeledDataJob(Job):
                 audio_trans = segment.orth
                 assert os.path.exists(audio_path), f"Path {audio_path} does not exist."
 
-                rel_audio_path = os.path.relpath(audio_path, common_dir)
+                rel_audio_path = os.path.relpath(audio_path, train_common_dir)
                 frames = soundfile.info(audio_path).frames
 
                 # determine whether to write to dest or valid
                 if rand.random() >= self.valid_percent:
-                    tsv_out = dest_tsv
-                    ltr_out = dest_ltr
-                    wrd_out = dest_wrd
+                    tsv_out = train_tsv
+                    ltr_out = train_ltr
+                    wrd_out = train_wrd
                 else:
                     tsv_out = valid_tsv
                     ltr_out = valid_ltr
@@ -148,14 +167,39 @@ class CreateFairseqLabeledDataJob(Job):
                 )
                 print(audio_trans, file=wrd_out)
         
+        # iterate over all validation corpora
+        if self.valid_corpus_paths and self.valid_percent <= 0:
+            for corpus_path in self.valid_corpus_paths:
+                corpus_object = corpus.Corpus()
+                corpus_object.load(corpus_path.get())
+                for segment in corpus_object.segments():
+                    # extract audio path and transcription from segment
+                    audio_path = segment.recording.audio
+                    audio_trans = segment.orth
+                    assert os.path.exists(audio_path), f"Path {audio_path} does not exist."
+
+                    rel_audio_path = os.path.relpath(audio_path, valid_common_dir)
+                    frames = soundfile.info(audio_path).frames
+
+                    # write audio path to tsv files
+                    print(f"{rel_audio_path}\t{frames}", file=valid_tsv)
+
+                    # write transcription to transcription files
+                    print(
+                        " ".join(list(audio_trans.replace(" ", "|"))) + " |",
+                        file=valid_ltr,
+                    )
+                    print(audio_trans, file=valid_wrd)
+
+
         # close all files
         valid_tsv.close()
         valid_ltr.close()
         valid_wrd.close()
         
-        dest_tsv.close()
-        dest_ltr.close()
-        dest_wrd.close()
+        train_tsv.close()
+        train_ltr.close()
+        train_wrd.close()
 
 
 
@@ -201,16 +245,37 @@ Z 213
         """
         Returns the common directory of all audios given in the corpora.
         """
-        common_dir = None
-        # iterate over all corpora
-        for corpus_path in self.corpus_paths:
+        train_common_dir = None
+        valid_common_dir = None
+        # iterate over all training corpora
+        for corpus_path in self.train_corpus_paths:
             corpus_object = corpus.Corpus()
             corpus_object.load(corpus_path.get())
             for segment in corpus_object.segments():
                 audio_path = segment.recording.audio
                 assert os.path.exists(audio_path), f"Path {audio_path} does not exist."
-                if common_dir is None:
-                    common_dir = os.path.dirname(audio_path)
+                if train_common_dir is None:
+                    train_common_dir = os.path.dirname(audio_path)
                 else:
-                    common_dir = os.path.commonpath([common_dir, os.path.dirname(audio_path)])
-        return common_dir
+                    train_common_dir = os.path.commonpath([train_common_dir, os.path.dirname(audio_path)])
+
+        for corpus_path in self.valid_corpus_paths:
+            corpus_object = corpus.Corpus()
+            corpus_object.load(corpus_path.get())
+            for segment in corpus_object.segments():
+                audio_path = segment.recording.audio
+                assert os.path.exists(audio_path), f"Path {audio_path} does not exist."
+                if valid_common_dir is None:
+                    valid_common_dir = os.path.dirname(audio_path)
+                else:
+                    valid_common_dir = os.path.commonpath([valid_common_dir, os.path.dirname(audio_path)])
+
+        return train_common_dir, valid_common_dir
+
+    def delete_valid_files():
+        """
+        Delete valid set files if no valid set was created.
+        """
+        os.remove(self.out_valid_tsv_path.get())
+        os.remove(self.out_valid_ltr_path.get())
+        os.remove(self.out_valid_wrd_path.get())

--- a/users/vieting/jobs/fairseq.py
+++ b/users/vieting/jobs/fairseq.py
@@ -53,7 +53,6 @@ class CreateFairseqLabeledDataJob(Job):
         :param sample_valid_name: name of the sampled validation label files. Default: "valid". 
             Ignored if sample_valid_percent is 0.
         :param create_letter_dict: if set to True, a dict.ltr.txt file will be created. Default: True
-        : 
         """
         if not isinstance(corpus_paths, list):
             corpus_paths = [corpus_paths]

--- a/users/vieting/jobs/fairseq.py
+++ b/users/vieting/jobs/fairseq.py
@@ -160,6 +160,45 @@ class CreateFairseqLabeledDataJob(Job):
         dest_wrd.close()
 
 
+    
+    def get_common_dir(self):
+        """
+        Returns the common directory of all audios given in the corpora.
+        """
+        common_dir = None
+        # iterate over all corpora
+        for corpus_path in self.corpus_paths:
+            corpus_object = corpus.Corpus()
+            corpus_object.load(corpus_path.get())
+            for segment in corpus_object.segments():
+                audio_path = segment.recording.audio
+                assert os.path.exists(audio_path), f"Path {audio_path} does not exist."
+                if common_dir is None:
+                    common_dir = os.path.dirname(audio_path)
+                else:
+                    common_dir = os.path.commonpath([common_dir, os.path.dirname(audio_path)])
+        return common_dir
+    def delete_valid_files():
+        """
+        Delete valid set files if no valid set was created.
+        """
+        os.remove(self.out_valid_tsv_path.get())
+        os.remove(self.out_valid_ltr_path.get())
+        os.remove(self.out_valid_wrd_path.get())
+
+class MergeLabeledFairseqDataJob(Job):
+    def __init__(
+        self,
+        labeled_data_paths: Union[List[tk.Path], tk.Path],
+        create_letter_dict: bool = True,
+    ):
+        pass
+
+    def tasks(self):
+        pass
+
+    def run(self):
+        pass
 
     def create_dict_ltr(self):
         """
@@ -197,29 +236,3 @@ Z 213
 """
         with open(self.out_dict_ltr_path.get(), 'w') as f:
             f.write(dict_ltr_content)
-
-    
-    def get_common_dir(self):
-        """
-        Returns the common directory of all audios given in the corpora.
-        """
-        common_dir = None
-        # iterate over all corpora
-        for corpus_path in self.corpus_paths:
-            corpus_object = corpus.Corpus()
-            corpus_object.load(corpus_path.get())
-            for segment in corpus_object.segments():
-                audio_path = segment.recording.audio
-                assert os.path.exists(audio_path), f"Path {audio_path} does not exist."
-                if common_dir is None:
-                    common_dir = os.path.dirname(audio_path)
-                else:
-                    common_dir = os.path.commonpath([common_dir, os.path.dirname(audio_path)])
-        return common_dir
-    def delete_valid_files():
-        """
-        Delete valid set files if no valid set was created.
-        """
-        os.remove(self.out_valid_tsv_path.get())
-        os.remove(self.out_valid_ltr_path.get())
-        os.remove(self.out_valid_wrd_path.get())

--- a/users/vieting/jobs/fairseq.py
+++ b/users/vieting/jobs/fairseq.py
@@ -14,9 +14,9 @@ from i6_core.lib import corpus
 class CreateFairseqLabeledDataJob(Job):
     """
     Creates required task files for wav2vec finetuning with fairseq. This includes the following files:
-    - dest.tsv
-    - dest.ltr
-    - dest.wrd
+    - <dest_name>.tsv
+    - <dest_name>.ltr
+    - <dest_name>.wrd
 
     For the script see https://github.com/pytorch/fairseq/blob/main/examples/wav2vec/wav2vec_manifest.py for .tsv creation,
     https://github.com/facebookresearch/fairseq/blob/91c364b7ceef8032099363cb10ba19a85b050c1c/examples/wav2vec/libri_labels.py 

--- a/users/vieting/jobs/fairseq.py
+++ b/users/vieting/jobs/fairseq.py
@@ -228,3 +228,4 @@ Z 213
 """
         with open(self.out_dict_ltr_path.get(), 'w') as f:
             f.write(dict_ltr_content)
+    

--- a/users/vieting/jobs/fairseq.py
+++ b/users/vieting/jobs/fairseq.py
@@ -19,17 +19,19 @@ class CreateFairseqLabeledDataJob(Job):
     If create_letter_dict is set to True, the following file will be created:
     - dict.ltr.txt
 
-    If sample_valid_percent is set > 0, a random sample of the files will be saved as validation set and the following files will be created:
+    If sample_valid_percent is set > 0, a random sample of the files will be saved as validation set 
+    and the following files will be created:
     - valid.tsv
     - valid.ltr
     - valid.wrd
     
 
     For the script see https://github.com/pytorch/fairseq/blob/main/examples/wav2vec/wav2vec_manifest.py for .tsv creation,
-    https://github.com/facebookresearch/fairseq/blob/91c364b7ceef8032099363cb10ba19a85b050c1c/examples/wav2vec/libri_labels.py as well as
-    the issue https://github.com/facebookresearch/fairseq/issues/2493 for .wrd and .ltr creation.
+    https://github.com/facebookresearch/fairseq/blob/91c364b7ceef8032099363cb10ba19a85b050c1c/examples/wav2vec/libri_labels.py 
+    as well as the issue https://github.com/facebookresearch/fairseq/issues/2493 for .wrd and .ltr creation.
 
-    See also https://github.com/rwth-i6/i6_experiments/blob/main/users/dierkes/preprocessing/wav2vec.py for only manifest creation job (e.g. for fairseq pre-training).
+    See also https://github.com/rwth-i6/i6_experiments/blob/main/users/dierkes/preprocessing/wav2vec.py for only 
+    manifest creation job (e.g. for fairseq pre-training).
     """
 
     def __init__(
@@ -51,6 +53,8 @@ class CreateFairseqLabeledDataJob(Job):
         :param path_must_contain: if set, path must contain this substring
             for a file to be included in the task
         :param dest_name: name of the main label files. Default: "train"
+        :param sample_valid_name: name of the sampled validation label files. Default: "valid". 
+            Ignored if sample_valid_percent is 0.
         :param create_letter_dict: if set to True, a dict.ltr.txt file will be created. Default: True
         : 
         """
@@ -90,7 +94,8 @@ class CreateFairseqLabeledDataJob(Job):
 
     def create_tsv_and_labels(self):
         """
-        Creates both tsv files (train.tsv, valid.tsv) and labels (train.ltr, train.wrd, valid.ltr, valid.wrd) from the given corpora.
+        Creates both tsv files (train.tsv, valid.tsv) and labels (train.ltr, train.wrd, valid.ltr, valid.wrd) 
+        from the given corpora.
         """
         rand = random.Random(self.seed)
         

--- a/users/vieting/jobs/fairseq.py
+++ b/users/vieting/jobs/fairseq.py
@@ -112,8 +112,9 @@ class CreateFairseqLabeledDataJob(Job):
         for corpus_path in self.corpus_paths:
             corpus_object = corpus.Corpus()
             corpus_object.load(corpus_path.get())
-            for recording in corpus_object.recordings():
-                audio_paths.append(recording.audio)
+            for recording in corpus_object.all_recordings():
+                audio_path = recording.audio
+                audio_paths.append(audio_path)
                 assert os.path.exists(audio_path), f"Path {audio_path} does not exist."
         common_dir = os.path.commonpath(audio_paths)
         return common_dir

--- a/users/vieting/jobs/fairseq.py
+++ b/users/vieting/jobs/fairseq.py
@@ -162,8 +162,6 @@ class MergeLabeledFairseqDataJob(Job):
         self.out_task_path = self.output_path("task", directory=True)
         self.out_dict_ltr_path = self.output_path("task/dict.ltr.txt")
 
-        self.rqmt = {"time": 6, "mem": 8, "cpu": 1}
-
     def tasks(self):
         yield Task("run", rqmt=self.rqmt, mini_task=True)
 

--- a/users/vieting/jobs/fairseq.py
+++ b/users/vieting/jobs/fairseq.py
@@ -3,6 +3,7 @@ import glob
 import os
 import random
 import subprocess
+import shutil
 import logging
 from typing import List, Union, Optional 
 
@@ -175,17 +176,11 @@ class MergeLabeledFairseqDataJob(Job):
             assert os.path.exists(path.get()), f"Path {path} does not exist."
 
             # iterature through directory "path" and copy all files to self.out_task_path directory
-            path_dir = os.fsencode(path.get())
-            for file in os.listdir(path_dir):
-                filename = os.fsdecode(file)
-                if filename.endswith(".tsv") or filename.endswith(".ltr") or filename.endswith(".wrd"):
-                    subprocess.run(
-                        [
-                            "cp",
-                            os.path.join(path.get(), filename),
-                            os.path.join(self.out_task_path, filename),
-                        ]
-                    )
+            for file in os.listdir(path.get()):
+                if file.endswith(".tsv") or file.endswith(".ltr") or file.endswith(".wrd"):
+                    src = os.path.join(path.get(), file)
+                    dst = os.path.join(self.out_task_path.get(), file)
+                    shutil.copyfile(src, dst)
                 else:
                     logging.warning(f"Ignoring File {filename}; is not a valid fairseq file.")
         


### PR DESCRIPTION
@vieting I noticed that the CreateFairseqLabeledDataJob was not well suited for using dedicated dev sets (dev-clean, dev-other in the case of LibriSpeech). I therefore changed some things and corrected some errors in the documentation as well. The changes were applied to all setups using that job (though it is not necessary, all existing setups should be able to work with the fixes as well).