### PR TITLE
Fairseq decoding

### DIFF
--- a/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
+++ b/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
@@ -421,6 +421,7 @@ def decode(model_path: tk.Path):
         dev_other_decoding.out_results
     )
 
+
 # ------------------- MAIN ------------------- #
 
 def main():

--- a/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
+++ b/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
@@ -341,8 +341,7 @@ def get_dev_labels(
     """
     assert audio_format in ["ogg", "wav", "flac"], f"audio format not implemented: '{audio_format}'"
     assert corpus_name in (
-        {"train-clean-100",
-         "dev-clean",
+        {"dev-clean",
          "dev-other",
          "test-clean",
          "test-other"}

--- a/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
+++ b/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
@@ -365,7 +365,6 @@ def get_dev_labels(
         file_extension=audio_format,
         dest_name=corpus_name,
     )
-    label_data_job.rqmt["time"] = 4
 
     return label_data_job.out_task_path
 

--- a/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
+++ b/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
@@ -37,7 +37,7 @@ def get_fairseq_root(fairseq_python_exe: Optional[tk.Path] = None):
 def get_labels(
     dest_name: str,
     corpus_paths: Union[List[tk.Path], tk.Path],
-):
+    ):
     """
     :param dest_name: name of the output file
     :param corpus_paths: path to the corpora
@@ -60,7 +60,7 @@ def get_task_dev_sampled(
     valid_percent: float = 0.01, 
     audio_format: str = "ogg", 
     output_prefix: str = "datasets",
-):
+    ):
     """
     :param corpus_name: name of the corpora to be used for training and to sample the dev set from
     :param valid_percent: percentage of the training data to be used as validation set. 
@@ -133,7 +133,7 @@ def get_task_dev_separate(
     dev_corpus_name: str,
     audio_format: str = "ogg",
     output_prefix: str = "datasets",
-):
+    ):
     """
     :param train_corpus_name: name of the corpus to be used for training set
     :param dev_corpus_name: name of the corpus to be used for validation set
@@ -322,6 +322,7 @@ def finetune():
     tk.register_output(os.path.join(prefix_name, exp_name, "finetune", "checkpoints"), job.out_checkpoint_dir)
 
     return job.out_checkpoint_dir
+
 
 # ------------------- DECODING ------------------- #
 

--- a/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
+++ b/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
@@ -362,7 +362,10 @@ def decode(model_path: tk.Path):
     """
     :param model_path: path to the model to be used for decoding
     """
-    FAIRSEQ_PYTHON_EXE = tk.Path("/work/asr3/vieting/hiwis/pletschko/miniconda3/envs/fairseq_python38/bin/python")
+    fairseq_python_exe = tk.Path(
+        "/work/asr3/vieting/hiwis/pletschko/miniconda3/envs/fairseq_python38/bin/python",
+        hash_overwrite="ls100_ctc_fairseq_python_exe",
+    )
     LM_URL = "https://www.openslr.org/resources/11/4-gram.arpa.gz"
     LEXICON_URL = "https://dl.fbaipublicfiles.com/fairseq/wav2vec/librispeech_lexicon.lst"
 

--- a/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
+++ b/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
@@ -362,6 +362,7 @@ def decode(model_path: tk.Path):
     """
     :param model_path: path to the model to be used for decoding
     """
+    # defines
     fairseq_python_exe = tk.Path(
         "/work/asr3/vieting/hiwis/pletschko/miniconda3/envs/fairseq_python38/bin/python",
         hash_overwrite="ls100_ctc_fairseq_python_exe",
@@ -372,7 +373,7 @@ def decode(model_path: tk.Path):
     prefix_name = "experiments/librispeech/librispeech_100_ctc/fairseq/"
     exp_name = "base"
 
-    # run decoding
+    # prepare labels and language model
     fairseq_root = get_fairseq_root()
 
     dev_clean = get_dev_labels(corpus_names=["dev-clean"])
@@ -382,6 +383,7 @@ def decode(model_path: tk.Path):
     lm_path = DownloadJob(url=lm_url).out_file
     lexicon_path = DownloadJob(url=lexicon_url).out_file
 
+    # run decoding
     dev_clean_decoding = FairseqDecodingJob(
         fairseq_python_exe=fairseq_python_exe,
         fairseq_root=fairseq_root,

--- a/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
+++ b/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
@@ -366,8 +366,8 @@ def decode(model_path: tk.Path):
         "/work/asr3/vieting/hiwis/pletschko/miniconda3/envs/fairseq_python38/bin/python",
         hash_overwrite="ls100_ctc_fairseq_python_exe",
     )
-    LM_URL = "https://www.openslr.org/resources/11/4-gram.arpa.gz"
-    LEXICON_URL = "https://dl.fbaipublicfiles.com/fairseq/wav2vec/librispeech_lexicon.lst"
+    lm_url = "https://www.openslr.org/resources/11/4-gram.arpa.gz"
+    lexicon_url = "https://dl.fbaipublicfiles.com/fairseq/wav2vec/librispeech_lexicon.lst"
 
     prefix_name = "experiments/librispeech/librispeech_100_ctc/fairseq/"
     exp_name = "base"
@@ -383,7 +383,7 @@ def decode(model_path: tk.Path):
     lexicon_path = DownloadJob(url=lexicon_url).out_file
 
     dev_clean_decoding = FairseqDecodingJob(
-        fairseq_python_exe=FAIRSEQ_PYTHON_EXE,
+        fairseq_python_exe=fairseq_python_exe,
         fairseq_root=fairseq_root,
         model_path=model_path,
         data_path=dev_clean,
@@ -394,7 +394,7 @@ def decode(model_path: tk.Path):
     )
 
     dev_other_decoding = FairseqDecodingJob(
-        fairseq_python_exe=FAIRSEQ_PYTHON_EXE,
+        fairseq_python_exe=fairseq_python_exe,
         fairseq_root=fairseq_root,
         model_path=model_path,
         data_path=dev_other,

--- a/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
+++ b/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
@@ -349,10 +349,10 @@ def get_dev_labels(
     # TODO has to be adapted when CreateFairseqLabeledDataJob is updated
     assert audio_format in ["ogg", "wav", "flac"], f"audio format not implemented: '{audio_format}'"
     assert corpus_name in (
-        {"train-clean-100", 
-         "dev-clean", 
-         "dev-other", 
-         "test-clean", 
+        {"train-clean-100",
+         "dev-clean",
+         "dev-other",
+         "test-clean",
          "test-other"}
     ), f"unknown corpus names: {corpus_name}"
 
@@ -366,7 +366,7 @@ def get_dev_labels(
         dest_name=corpus_name,
     )
     label_data_job.rqmt["time"] = 4
-    
+
     return label_data_job.out_task_path
 
 
@@ -414,7 +414,7 @@ def decode(model_path: tk.Path):
     )
 
     tk.register_output(
-        os.path.join(prefix_name, exp_name, "decode", "dev-clean", "results"), 
+        os.path.join(prefix_name, exp_name, "decode", "dev-clean", "results"),
         dev_clean_decoding.out_results
     )
     tk.register_output(
@@ -428,5 +428,5 @@ def main():
     out_checkpoint_dir = finetune()
     checkpoint_best = tk.Path(os.path.join(out_checkpoint_dir.get(), "checkpoint_best.pt"))
     decode(checkpoint_best)
-    
+
 main()

--- a/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
+++ b/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
@@ -348,7 +348,7 @@ def get_dev_labels(
     ), f"unknown corpus names: {corpus_name}"
 
     corpus_dict = get_bliss_corpus_dict(audio_format=audio_format, output_prefix=output_prefix)
-    # filter out corpora that are not in corpus_names
+    # select corpus given by corpus_name
     corpus_path = corpus_dict[corpus_name]
 
     return get_labels(

--- a/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
+++ b/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
@@ -340,12 +340,12 @@ def get_dev_labels(
     :param corpus_names: list of names of the corpora to be used for decoding
     """
     assert audio_format in ["ogg", "wav", "flac"], f"audio format not implemented: '{audio_format}'"
-    assert corpus_name in (
-        {"dev-clean",
-         "dev-other",
-         "test-clean",
-         "test-other"}
-    ), f"unknown corpus names: {corpus_name}"
+    assert corpus_name in ({
+        "dev-clean",
+        "dev-other",
+        "test-clean",
+        "test-other",
+    }), f"unknown corpus names: {corpus_name}"
 
     corpus_dict = get_bliss_corpus_dict(audio_format=audio_format, output_prefix=output_prefix)
     # select corpus given by corpus_name

--- a/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
+++ b/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
@@ -373,10 +373,10 @@ def decode(model_path: tk.Path):
     exp_name = "base"
 
     # prepare labels and language model
-    fairseq_root = get_fairseq_root()
+    fairseq_root = get_fairseq_root(fairseq_python_exe=fairseq_python_exe)
 
-    dev_clean = get_dev_labels(corpus_names=["dev-clean"])
-    dev_other = get_dev_labels(corpus_names=["dev-other"])
+    dev_clean = get_dev_labels(corpus_name="dev-clean")
+    dev_other = get_dev_labels(corpus_name="dev-other")
 
     decoder = "kenlm"
     lm_path = DownloadJob(url=lm_url).out_file

--- a/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
+++ b/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
@@ -329,20 +329,6 @@ def finetune():
 
 # ------------------- DECODING ------------------- #
 
-def get_language_model(lm_url: str):
-    """
-    :param lm_url: url to the language model
-    """
-    lm_path = DownloadJob(url=lm_url).out_file
-    return lm_path
-
-def get_lexicon(lexicon_url: str):
-    """
-    :param lexicon_url: url to the lexicon
-    """
-    lexicon_path = DownloadJob(url=lexicon_url).out_file
-    return lexicon_path
-
 def get_dev_labels(
     audio_format: str = "ogg",
     output_prefix: str = "datasets",
@@ -390,8 +376,8 @@ def decode(model_path: tk.Path):
     dev_other = get_dev_labels(corpus_names=["dev-other"])
 
     decoder = "kenlm"
-    lm_path = get_language_model(LM_URL)
-    lexicon_path = get_lexicon(LEXICON_URL)
+    lm_path = DownloadJob(url=lm_url).out_file
+    lexicon_path = DownloadJob(url=lexicon_url).out_file
 
     dev_clean_decoding = FairseqDecodingJob(
         fairseq_python_exe=FAIRSEQ_PYTHON_EXE,

--- a/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
+++ b/users/vieting/experiments/librispeech/librispeech_100_ctc/fairseq_finetuning/config_01_finetune.py
@@ -14,8 +14,11 @@ from recipe.i6_core.corpus.segments import ShuffleAndSplitSegmentsJob, SegmentCo
 from recipe.i6_core.corpus.filter import FilterCorpusBySegmentsJob
 from recipe.i6_experiments.common.datasets.librispeech.corpus import get_bliss_corpus_dict
 from recipe.i6_experiments.users.engler.fairseq.training import FairseqHydraConfig, FairseqHydraTrainingJob
-from recipe.i6_experiments.users.vieting.jobs.fairseq import CreateFairseqLabeledDataJob, MergeLabeledFairseqDataJob, \
-    FairseqDecodingJob
+from recipe.i6_experiments.users.vieting.jobs.fairseq import (
+    CreateFairseqLabeledDataJob,
+    MergeLabeledFairseqDataJob,
+    FairseqDecodingJob,
+)
 from recipe.i6_experiments.users.vieting.experiments.librispeech.librispeech_960_pretraining.wav2vec2.fairseq \
     import SetupFairseqJob
 
@@ -37,7 +40,7 @@ def get_fairseq_root(fairseq_python_exe: Optional[tk.Path] = None):
 def get_labels(
     dest_name: str,
     corpus_paths: Union[List[tk.Path], tk.Path],
-    ):
+):
     """
     :param dest_name: name of the output file
     :param corpus_paths: path to the corpora
@@ -60,7 +63,7 @@ def get_task_dev_sampled(
     valid_percent: float = 0.01, 
     audio_format: str = "ogg", 
     output_prefix: str = "datasets",
-    ):
+):
     """
     :param corpus_name: name of the corpora to be used for training and to sample the dev set from
     :param valid_percent: percentage of the training data to be used as validation set. 
@@ -133,7 +136,7 @@ def get_task_dev_separate(
     dev_corpus_name: str,
     audio_format: str = "ogg",
     output_prefix: str = "datasets",
-    ):
+):
     """
     :param train_corpus_name: name of the corpus to be used for training set
     :param dev_corpus_name: name of the corpus to be used for validation set
@@ -341,10 +344,10 @@ def get_lexicon(lexicon_url: str):
     return lexicon_path
 
 def get_dev_labels(
-        audio_format: str = "ogg",
-        output_prefix: str = "datasets",
-        corpus_name: str = "dev-other"
-    ):
+    audio_format: str = "ogg",
+    output_prefix: str = "datasets",
+    corpus_name: str = "dev-other"
+):
     """
     :param audio_format: audio format of the output files
     :param output_prefix: prefix of the output files

--- a/users/vieting/jobs/fairseq.py
+++ b/users/vieting/jobs/fairseq.py
@@ -240,9 +240,9 @@ class FairseqDecodingJob(Job):
             - [gen_subset].[labels] (e.g. ltr)
         :param gen_subset: name of the subset to be decoded. The files in data_path should be named correspondingly.
         :param nbest: number of nbest hypotheses to output, default 1
-        :param w2l_decoder: decoder to use, default "viterbi". Can be "viterbi", "kenlm" or "fairseqlm". 
+        :param w2l_decoder: decoder to use, default "viterbi". Can be "viterbi", "kenlm" or "fairseqlm".
         :param lm_path: path to language model, default None. Only required if w2l_decoder is "kenlm" or "fairseqlm".
-        :param lm_lexicon: path to lexicon for language model, default None. 
+        :param lm_lexicon: path to lexicon for language model, default None.
             Only required if w2l_decoder is "kenlm" or "fairseqlm".
         :param lm_weight: weight of language model, default 2.0
         :param word_score: word score, default 1.0
@@ -250,7 +250,7 @@ class FairseqDecodingJob(Job):
         :param criterion: criterion to use, default "ctc". At the moment, only "ctc" is tested.
         :param labels: labels to use, default "ltr". At the moment, only "ltr" is tested. 
             The data_path folder should contain a file with the corresponding file extension.
-        :param post_process: post processing to use, default "letter". 
+        :param post_process: post processing to use, default "letter".
             Can be "letter", "sentencepiece", "wordpiece", "letter", "silence", "subword_nmt", "_EOW" or "none".
             (just use "letter" for now)
         :param max_tokens: maximum number of tokens to decode, default 4000000
@@ -298,11 +298,11 @@ class FairseqDecodingJob(Job):
 
     def tasks(self):
         yield Task("run", rqmt=self.rqmt)
-    
+
     def run(self):
         my_env = os.environ
         sp.check_call(self._get_run_cmd(), env=my_env)
-    
+
     def _get_run_cmd(self):
         fairseq_infer_path = os.join(self.fairseq_root.get(), "examples", "speech_recognition", "infer.py")
         run_cmd = [

--- a/users/vieting/jobs/fairseq.py
+++ b/users/vieting/jobs/fairseq.py
@@ -257,6 +257,7 @@ class FairseqDecodingJob(Job):
         """
 
         # inputs
+        self.fairseq_python_exe = fairseq_python_exe
         self.fairseq_root = fairseq_root
         self.model_path = model_path
         self.data_path = data_path
@@ -306,12 +307,16 @@ class FairseqDecodingJob(Job):
 
     def run(self):
         my_env = os.environ
+        if "PYTHONPATH" in my_env:
+            my_env["PYTHONPATH"] += f":{self.fairseq_root.get()}"
+        else:
+            my_env["PYTHONPATH"] = f"{self.fairseq_root.get()}"
         run_cmd = self._get_run_cmd()
         logging.info(f"Running decoding with following run command: {' '.join(run_cmd)}")
         sp.check_call(run_cmd, env=my_env)
 
     def _get_run_cmd(self):
-        fairseq_infer_path = os.join(self.fairseq_root.get(), "examples", "speech_recognition", "infer.py")
+        fairseq_infer_path = os.path.join(self.fairseq_root.get(), "examples", "speech_recognition", "infer.py")
         run_cmd = [
             self.fairseq_python_exe.get(),
             fairseq_infer_path,
@@ -321,7 +326,7 @@ class FairseqDecodingJob(Job):
             "--path", self.model_path.get(),
             "--gen-subset", self.gen_subset,
             "--w2l-decoder", self.w2l_decoder,
-            "--lm-path", self.lm_path.get(),
+            "--lm-model", self.lm_path.get(),
             "--lexicon", self.lm_lexicon.get(),
             "--lm-weight", str(self.lm_weight),
             "--word-score", str(self.word_score),

--- a/users/vieting/jobs/fairseq.py
+++ b/users/vieting/jobs/fairseq.py
@@ -204,4 +204,37 @@ Z 213
 """
         with open(self.out_dict_ltr_path.get(), 'w') as f:
             f.write(dict_ltr_content)
-    
+
+
+class FairseqDecodingJob(Job):
+    """
+    Runs decoding with fairseq on a given fine-tuned model and a given data set.
+
+
+    """
+    def __init__(
+            fairseq_root: tk.Path,
+            model_path: tk.Path,
+            data_path: tk.Path,
+            nbest: int = 1,
+            subset_name: str = "valid",
+            w2l_decoder: str = "viterbi",
+            lm_path: Optional[tk.Path] = None,
+            lm_lexicon: Optional[tk.Path] = None,
+            lm_weight: float = 2.0,
+            word_score: float = 1.0,
+            sil_weight: float = 0.0,
+            criterion: str = "ctc",
+            labels: str = "ltr",
+            post_process: str = "letter",
+            max_tokens: int = 4000000,
+    ):
+        """
+        :param fairseq_root: path to fairseq root directory
+        :param model_path: path to fine-tuned model
+        :param data_path: path
+        :param nbest: number of nbest hypotheses to output, default 1
+        :param subset_name: name of
+        :param w2l_decoder: decoder to use, default "viterbi". Can be "viterbi" or "kenlm"
+        """
+        pass

--- a/users/vieting/jobs/fairseq.py
+++ b/users/vieting/jobs/fairseq.py
@@ -301,7 +301,9 @@ class FairseqDecodingJob(Job):
 
     def run(self):
         my_env = os.environ
-        sp.check_call(self._get_run_cmd(), env=my_env)
+        run_cmd = self._get_run_cmd()
+        logging.info(f"Running decoding with following run command: {' '.join(run_cmd)}")
+        sp.check_call(run_cmd, env=my_env)
 
     def _get_run_cmd(self):
         fairseq_infer_path = os.join(self.fairseq_root.get(), "examples", "speech_recognition", "infer.py")

--- a/users/vieting/jobs/fairseq.py
+++ b/users/vieting/jobs/fairseq.py
@@ -208,7 +208,7 @@ Z 213
 
 class FairseqDecodingJob(Job):
     """
-    Runs decoding with fairseq on a given fine-tuned model and a given data set.
+    Runs decoding with fairseq for a given fine-tuned model and a given data set.
 
     Yields hypotheses and targets files in both word format and specified post-processing format.
     """

--- a/users/vieting/jobs/fairseq.py
+++ b/users/vieting/jobs/fairseq.py
@@ -292,6 +292,11 @@ class FairseqDecodingJob(Job):
 
         # outputs
         self.out_results = self.output_path("results", directory=True)
+        model_name = os.path.basename(self.model_path.get())
+        self.out_hyp_word = self.output_path(f"results/hypo.word-{model_name}-{self.gen_subset}.txt")
+        self.out_hyp_units = self.output_path(f"results/hypo.units-{model_name}-{self.gen_subset}.txt")
+        self.out_ref_word = self.output_path(f"results/ref.word-{model_name}-{self.gen_subset}.txt")
+        self.out_ref_units = self.output_path(f"results/ref.units-{model_name}-{self.gen_subset}.txt")
 
         # rqmt
         self.rqmt = {"time": 6, "mem": 8, "cpu": 1, "gpu": 1}

--- a/users/vieting/jobs/fairseq.py
+++ b/users/vieting/jobs/fairseq.py
@@ -2,7 +2,7 @@ import soundfile
 import glob
 import os
 import random
-import subprocess
+import subprocess as sp
 import shutil
 import logging
 from typing import List, Union, Optional 


### PR DESCRIPTION
@vieting I worked on a job for decoding fairseq wav2vec models in the `fairseq.py` and added the decoding to the fairseq finetune pipeline in the `config_01_finetune.py`. For the job layout, I oriented around the already existing and frequently used `FairseqHydraTrainingJob` (see [here](https://github.com/rwth-i6/i6_experiments/blob/main/users/engler/fairseq/training.py)).

I also used the opportunity to tidy up the config for the finetune pipeline, making more clear which parts belong where. 