### PR TITLE
Perform update before installing libsndfile in hash check action

### DIFF
--- a/.github/workflows/hashes.yml
+++ b/.github/workflows/hashes.yml
@@ -28,7 +28,7 @@ jobs:
     - run: |
         pip install --user --upgrade pip setuptools wheel
         pip install flask
-        sudo apt update && apt install -y libsndfile1
+        sudo apt update && sudo apt install -y libsndfile1
         pip install -r recipe/i6_core/requirements.txt
     - name: Setup Sisyphus environment
       run: |

--- a/.github/workflows/hashes.yml
+++ b/.github/workflows/hashes.yml
@@ -28,7 +28,7 @@ jobs:
     - run: |
         pip install --user --upgrade pip setuptools wheel
         pip install flask
-        sudo apt-get install -y libsndfile1
+        sudo apt update && apt install -y libsndfile1
         pip install -r recipe/i6_core/requirements.txt
     - name: Setup Sisyphus environment
       run: |


### PR DESCRIPTION
Version stored in apt cache can be out of date and no longer present in the mirror, causing for example https://github.com/rwth-i6/i6_experiments/actions/runs/6219531486/job/16877777086?pr=156 to fail.