### PR TITLE
Datastream helpers

### DIFF
--- a/common/setups/returnn/datastreams/audio.py
+++ b/common/setups/returnn/datastreams/audio.py
@@ -8,8 +8,8 @@ from typing import *
 from i6_core.returnn import ReturnnConfig
 from i6_core.returnn.dataset import ExtractDatasetMeanStddevJob
 
-from i6_experiments.users.rossenbach.common_setups.returnn.datastreams.base import Datastream
-from i6_experiments.users.rossenbach.common_setups.returnn.datasets.audio import OggZipDataset
+from .base import Datastream
+from ..datasets.audio import OggZipDataset
 
 
 class AdditionalFeatureOptions(ABC):

--- a/common/setups/returnn/datastreams/audio.py
+++ b/common/setups/returnn/datastreams/audio.py
@@ -50,11 +50,11 @@ class MFCCOptions(AdditionalFeatureOptions):
 
 # list of known audio feature type with their respective options type
 KNOWN_FEATURES = {
-    "mfcc": [type(None), MFCCOptions],
-    "log_mel_filterbank": [type(None)],
-    "log_log_mel_filterbank": [type(None)],
-    "db_mel_filterbank": [type(None), DBMelFilterbankOptions],
-    "linear_spectrogram": [type(None), LinearFilterbankOptions],
+    "mfcc": [MFCCOptions],
+    "log_mel_filterbank": [],
+    "log_log_mel_filterbank": [],
+    "db_mel_filterbank": [DBMelFilterbankOptions],
+    "linear_spectrogram": [LinearFilterbankOptions],
 }
 
 
@@ -137,8 +137,7 @@ class AudioFeatureDatastream(Datastream):
 
         if options.features not in KNOWN_FEATURES:
             print("Warning: %s is not a known feature type" % options.features)
-
-        if type(options.feature_options) not in KNOWN_FEATURES.get(options.features, [type(None)]):
+        elif type(options.feature_options) not in KNOWN_FEATURES[options.features] + [type(None)]:
             print(
                 "Warning: possible feature options mismatch, passed %s but expected %s"
                 % (

--- a/common/setups/returnn/datastreams/audio.py
+++ b/common/setups/returnn/datastreams/audio.py
@@ -1,0 +1,255 @@
+from abc import ABC
+import dataclasses
+from enum import Enum
+import os.path
+from sisyphus import tk
+from typing import *
+
+from i6_core.returnn import ReturnnConfig
+from i6_core.returnn.dataset import ExtractDatasetMeanStddevJob
+
+from i6_experiments.users.rossenbach.common_setups.returnn.datastreams.base import Datastream
+from i6_experiments.users.rossenbach.common_setups.returnn.datasets.audio import OggZipDataset
+
+
+class AdditionalFeatureOptions(ABC):
+    pass
+
+
+@dataclasses.dataclass(frozen=True)
+class DBMelFilterbankOptions(AdditionalFeatureOptions):
+    """
+    additional options for the db_mel_filterbank features
+    """
+
+    fmin: int = 0
+    fmax: int = None
+    min_amp: float = 1e-10
+    center: bool = True
+
+
+@dataclasses.dataclass(frozen=True)
+class LinearFilterbankOptions(AdditionalFeatureOptions):
+    """
+    additional options for linear_spectrogram features
+    """
+
+    center: bool = True
+
+
+@dataclasses.dataclass(frozen=True)
+class MFCCOptions(AdditionalFeatureOptions):
+    """
+    additional options for the mfcc features
+    """
+
+    fmin: int = 0
+    fmax: int = None
+    n_mels: int = 128
+
+
+# list of known audio feature type with their respective options type
+KNOWN_FEATURES = {
+    "mfcc": [type(None), MFCCOptions],
+    "log_mel_filterbank": [type(None)],
+    "log_log_mel_filterbank": [type(None)],
+    "db_mel_filterbank": [type(None), DBMelFilterbankOptions],
+    "linear_spectrogram": [type(None), LinearFilterbankOptions],
+}
+
+
+class FeatureType(Enum):
+    """
+    Enum helper to have auto-completion for feature types
+    """
+
+    MFCC = "mfcc"
+    LOG_MEL_FILTERBANK = "log_mel_filterbank"
+    LOG_LOG_MEL_FILTERBANK = "log_log_mel_filterbank"
+    DB_MEL_FILTERBANK = "db_mel_filterbank"
+    LINEAR_SPECTROGRAM = "linear_spectrogram"
+
+
+@dataclasses.dataclass(frozen=True)
+class ReturnnAudioFeatureOptions:
+    """
+    Commonly used options for RETURNN feature extraction (e.g. with OggZip) and AudioFeatureDatastream
+
+    :param window_len:
+    :param step_len:
+    :param num_feature_filters:
+    :param with_delta:
+    :param features:
+    :param additional_feature_options:
+    :param sample_rate: audio sample rate, this is not strictly required for RETURNN itself
+        but might be needed for certain pipelines
+    :param peak_normalization:
+    :param preemphasis:
+    """
+
+    window_len: float = 0.025
+    step_len: float = 0.010
+    num_feature_filters: int = None
+    with_delta: bool = False
+    features: Union[str, FeatureType] = "mfcc"
+    feature_options: Optional[Union[dict, AdditionalFeatureOptions]] = None
+    sample_rate: Optional[int] = None
+    peak_normalization: bool = True
+    preemphasis: float = None
+
+    def __post_init__(self):
+        # convert Enum back to str
+        if isinstance(self.features, FeatureType):
+            # dataclass is frozen, so directly alter the self.__dict__
+            self.__dict__["features"] = self.features.value
+
+
+@dataclasses.dataclass(frozen=True)
+class ReturnnAudioRawOptions:
+    """
+    options for an AudioRawDatastream
+    """
+
+    peak_normalization: bool = True
+    preemphasis: float = None
+
+
+class AudioFeatureDatastream(Datastream):
+    """
+    Encapsulates options for audio features used by OggZipDataset via :class:`ExtractAudioFeaturesOptions` in RETURNN
+    """
+
+    def __init__(
+        self,
+        available_for_inference: bool,
+        options: ReturnnAudioFeatureOptions,
+        **kwargs,
+    ):
+        """
+        :param available_for_inference: define if the DataStream is available during decoding/search. If False,
+            it is only available during training.
+        :param options: An audio feature options object with the desired feature settings
+        :param kwargs: additional options that are passed manually
+        """
+        super().__init__(available_for_inference)
+        self.options = options
+        self.additional_options = kwargs.copy()
+
+        if options.features not in KNOWN_FEATURES:
+            print("Warning: %s is not a known feature type" % options.features)
+
+        if type(options.feature_options) not in KNOWN_FEATURES.get(options.features, [type(None)]):
+            print(
+                "Warning: possible feature options mismatch, passed %s but expected %s"
+                % (
+                    str(type(options.feature_options)),
+                    str(KNOWN_FEATURES.get(options.features, type(None))),
+                )
+            )
+
+    def get_feat_dim(self):
+        if "num_feature_filters" in self.additional_options:
+            return self.additional_options["num_feature_filters"]
+        elif self.additional_options["features"] == "raw":
+            return 1
+        return 40  # some default value
+
+    def as_returnn_extern_data_opts(self, available_for_inference: Optional[bool] = None) -> Dict[str, Any]:
+        """
+        :param bool available_for_inference: allows to overwrite the given state if desired. This can be used in case
+            the stream is used as output of one model but as input to the next one.
+        :return: dictionary for an `extern_data` entry.
+        """
+        feat_dim = self.options.num_feature_filters
+        return {
+            **super().as_returnn_extern_data_opts(available_for_inference=available_for_inference),
+            "shape": (None, feat_dim),
+            "dim": feat_dim,
+        }
+
+    def as_returnn_audio_opts(self) -> Dict[str, Any]:
+        """
+        :return: dictionary for `ExtractAudioFeatures` parameters, e.g. as `audio` parameter of the OggZipDataset
+        """
+        audio_opts_dict = dataclasses.asdict(self.options)
+        audio_opts_dict.update(self.additional_options)
+        return audio_opts_dict
+
+    def add_global_statistics_to_audio_feature_datastream(
+        self,
+        zip_datasets: List[tk.Path],
+        segment_file: Optional[tk.Path] = None,
+        use_scalar_only: bool = False,
+        returnn_python_exe: Optional[tk.Path] = None,
+        returnn_root: Optional[tk.Path] = None,
+        alias_path: str = "",
+    ):
+        """
+        Computes the global feature statistics over a corpus given as zip-dataset.
+        Can either add the statistics per channel (default) or as scalar.
+
+        :param zip_datasets: zip dataset which is used for statistics calculation
+        :param segment_file: segment file for the dataset
+        :param use_scalar_only: use one scalar for mean and variance instead one value per feature channel.
+            This is usually done for TTS.
+        :param returnn_python_exe:
+        :param returnn_root:
+        :param alias_path: sets alias folder for ExtractDatasetStatisticsJob
+        :return: audio datastream with added global feature statistics
+        :rtype: AudioFeatureDatastream
+        """
+        extraction_dataset = OggZipDataset(
+            path=zip_datasets,
+            segment_file=segment_file,
+            audio_options=self.as_returnn_audio_opts(),
+            target_options=None,
+        )
+
+        extraction_config = ReturnnConfig(config={"train": extraction_dataset.as_returnn_opts()})
+        extract_dataset_statistics_job = ExtractDatasetMeanStddevJob(
+            extraction_config, returnn_python_exe=returnn_python_exe, returnn_root=returnn_root
+        )
+        extract_dataset_statistics_job.add_alias(os.path.join(alias_path, "extract_dataset_statistics_job"))
+        if use_scalar_only:
+            self.additional_options["norm_mean"] = extract_dataset_statistics_job.out_mean
+            self.additional_options["norm_std_dev"] = extract_dataset_statistics_job.out_std_dev
+        else:
+            self.additional_options["norm_mean"] = extract_dataset_statistics_job.out_mean_file
+            self.additional_options["norm_std_dev"] = extract_dataset_statistics_job.out_std_dev_file
+
+
+class AudioRawDatastream(Datastream):
+    """
+    Encapsulates options for audio features used by OggZipDataset via :class:`ExtractAudioFeaturesOptions` in RETURNN
+    """
+
+    def __init__(
+        self,
+        available_for_inference: bool,
+        options: ReturnnAudioRawOptions,
+        **kwargs,
+    ):
+        super().__init__(available_for_inference)
+        self.options = options
+
+    def as_returnn_extern_data_opts(self, available_for_inference: Optional[bool] = None) -> Dict[str, Any]:
+        """
+        :param bool available_for_inference: allows to overwrite the given state if desired. This can be used in case
+            the stream is used as output of one model but as input to the next one.
+        :return: dictionary for an `extern_data` entry.
+        """
+        return {
+            **super().as_returnn_extern_data_opts(available_for_inference=available_for_inference),
+            "shape": (None, 1),
+            "dim": 1,
+        }
+
+    def as_returnn_data_opts(self, available_for_inference: Optional[bool] = None) -> Dict[str, Any]:
+        return self.as_returnn_extern_data_opts(available_for_inference=available_for_inference)
+
+    def as_returnn_audio_opts(self) -> Dict[str, Any]:
+        """
+        :return: dictionary for `ExtractAudioFeatures` parameters, e.g. as `audio` parameter of the OggZipDataset
+        """
+        audio_opts_dict = dataclasses.asdict(self.options)
+        return {"features": "raw", **audio_opts_dict}

--- a/common/setups/returnn/datastreams/base.py
+++ b/common/setups/returnn/datastreams/base.py
@@ -1,0 +1,95 @@
+from sisyphus import tk
+from typing import *
+
+from i6_experiments.common.setups.returnn_common.serialization import DataInitArgs, DimInitArgs
+
+
+class Datastream:
+    """
+    Defines a "Datastream" for a setup, e.g. related to an entry in the "extern_data" dictionary
+    of the RETURNN config.
+
+    This can be raw audio, audio-features, text labels, speaker labels etc...
+    """
+
+    def __init__(self, available_for_inference: bool):
+        """
+
+        :param available_for_inference: "default" value for "available_for_inference"
+        """
+        self.available_for_inference = available_for_inference
+
+    def as_returnn_extern_data_opts(self, available_for_inference: Optional[bool] = None) -> Dict[str, Any]:
+        """
+        generates an option dictionary to be used as value of an `extern_data` entry.
+
+        :param available_for_inference: allows to overwrite "available_for_inference" directly
+        """
+        opts = {
+            "available_for_inference": available_for_inference
+            if available_for_inference is not None
+            else self.available_for_inference,
+        }
+        return opts
+
+    def as_nnet_constructor_data(self, name: str, available_for_inference: Optional[bool] = None, **kwargs):
+        d = self.as_returnn_extern_data_opts(available_for_inference=available_for_inference)
+        time_dim = DimInitArgs(
+            name="%s_time" % name,
+            dim=None,
+        )
+
+        dim = d["dim"]
+
+        if d.get("sparse", False):
+            sparse_dim = DimInitArgs(name="%s_indices" % name, dim=dim, is_feature=True)
+            return DataInitArgs(
+                name=name,
+                available_for_inference=d["available_for_inference"],
+                dim_tags=[time_dim],
+                sparse_dim=sparse_dim,
+            )
+        else:
+            feature_dim = DimInitArgs(
+                name="%s_feature" % name,
+                dim=dim,
+                is_feature=True,
+            )
+            return DataInitArgs(
+                name=name,
+                available_for_inference=d["available_for_inference"],
+                dim_tags=[time_dim, feature_dim],
+                sparse_dim=None,
+            )
+
+
+class FeatureDatastream(Datastream):
+    """
+    Defines a datastream for an arbitrary feature
+    """
+
+    def __init__(
+        self,
+        available_for_inference: bool,
+        feature_size: Union[tk.Variable, int],
+    ):
+        """
+
+        :param bool available_for_inference:
+        :Param tk.Variable|int embedding_size:
+        """
+        super().__init__(available_for_inference)
+        self.feature_size = feature_size
+
+    def as_returnn_extern_data_opts(self, available_for_inference: Optional[bool] = None, **kwargs) -> Dict[str, Any]:
+        """
+        :param available_for_inference:
+        :rtype: dict[str]
+        """
+        d = {
+            **super().as_returnn_extern_data_opts(available_for_inference=available_for_inference),
+            "shape": (None, self.feature_size),
+            "dim": self.feature_size,
+        }
+        d.update(kwargs)
+        return d

--- a/common/setups/returnn/datastreams/base.py
+++ b/common/setups/returnn/datastreams/base.py
@@ -1,8 +1,6 @@
 from sisyphus import tk
 from typing import *
 
-from i6_experiments.common.setups.returnn_common.serialization import DataInitArgs, DimInitArgs
-
 
 class Datastream:
     """
@@ -32,40 +30,10 @@ class Datastream:
         }
         return opts
 
-    def as_nnet_constructor_data(self, name: str, available_for_inference: Optional[bool] = None, **kwargs):
-        d = self.as_returnn_extern_data_opts(available_for_inference=available_for_inference)
-        time_dim = DimInitArgs(
-            name="%s_time" % name,
-            dim=None,
-        )
-
-        dim = d["dim"]
-
-        if d.get("sparse", False):
-            sparse_dim = DimInitArgs(name="%s_indices" % name, dim=dim, is_feature=True)
-            return DataInitArgs(
-                name=name,
-                available_for_inference=d["available_for_inference"],
-                dim_tags=[time_dim],
-                sparse_dim=sparse_dim,
-            )
-        else:
-            feature_dim = DimInitArgs(
-                name="%s_feature" % name,
-                dim=dim,
-                is_feature=True,
-            )
-            return DataInitArgs(
-                name=name,
-                available_for_inference=d["available_for_inference"],
-                dim_tags=[time_dim, feature_dim],
-                sparse_dim=None,
-            )
-
 
 class FeatureDatastream(Datastream):
     """
-    Defines a datastream for an arbitrary feature
+    Defines a datastream for an arbitrary feature, e.g. from an HDFDataset
     """
 
     def __init__(
@@ -74,9 +42,8 @@ class FeatureDatastream(Datastream):
         feature_size: Union[tk.Variable, int],
     ):
         """
-
-        :param bool available_for_inference:
-        :Param tk.Variable|int embedding_size:
+        :param available_for_inference:
+        :param feature_size: feature dimension
         """
         super().__init__(available_for_inference)
         self.feature_size = feature_size

--- a/common/setups/returnn/datastreams/vocabulary.py
+++ b/common/setups/returnn/datastreams/vocabulary.py
@@ -1,0 +1,146 @@
+from sisyphus import tk
+from typing import Any, Dict, Optional
+
+from i6_core.lm.vocabulary import LmIndexVocabulary
+
+from i6_experiments.users.rossenbach.setups.returnn_standalone.data.bpe import (
+    BPESettings,
+)
+
+from .base import Datastream
+
+
+class LabelDatastream(Datastream):
+    """
+    Defines a datastream for labels represented by indices using the default `Vocabulary` class of RETURNN
+
+    This defines a word-(unit)-based vocabulary
+    """
+
+    def __init__(
+        self,
+        available_for_inference: bool,
+        vocab: tk.Path,
+        vocab_size: tk.Variable,
+        unk_label=None,
+    ):
+        """
+
+        :param bool available_for_inference:
+        :param tk.Path vocab: word vocab file path (pickle)
+        :Param tk.Variable|int vocab_size:
+        :param str unk_label: unknown label
+        """
+        super().__init__(available_for_inference)
+        self.vocab = vocab
+        self.vocab_size = vocab_size
+        self.unk_label = unk_label
+
+    def as_returnn_extern_data_opts(self, available_for_inference: Optional[bool] = None, **kwargs) -> Dict[str, Any]:
+        """
+        :param tk.Variable|int vocab_size: number of labels
+        :rtype: dict[str]
+        """
+        d = {
+            **super().as_returnn_extern_data_opts(available_for_inference=available_for_inference),
+            "shape": (None,),
+            "dim": self.vocab_size,
+            "sparse": True,
+        }
+        d.update(kwargs)
+        return d
+
+    def as_returnn_targets_opts(self, **kwargs):
+        """
+        :rtype: dict[str]
+        """
+        return {"vocab_file": self.vocab, "unknown_label": self.unk_label, **kwargs}
+
+
+class LmLabelDatastream(LabelDatastream):
+    """
+    Same as LabelDatastream but uses LmIndexVocabulary objects as input
+    """
+
+    def __init__(self, available_for_inference: bool, lm_index_vocab: LmIndexVocabulary):
+        """
+
+        :param available_for_inference:
+        :param lm:
+        """
+        super().__init__(
+            available_for_inference=available_for_inference,
+            vocab=lm_index_vocab.vocab,
+            vocab_size=lm_index_vocab.vocab_size,
+            unk_label=lm_index_vocab.unknown_token,
+        )
+
+
+class BpeDatastream(LabelDatastream):
+    """
+    This defines a datastream using the BytePairEncoding(Vocabulary) class of RETURNN
+    """
+
+    def __init__(self, available_for_inference, bpe_settings, seq_postfix=0, use_unk_label=False):
+        """
+        :param BPESettings bpe_settings:
+        :param Path vocab: vocab file path
+        :param bool use_unk_label: unk_label should never be used for training
+        """
+        super(BpeDatastream, self).__init__(
+            available_for_inference=available_for_inference,
+            vocab=bpe_settings.bpe_vocab,
+            vocab_size=bpe_settings.bpe_vocab_size,
+            unk_label=bpe_settings.unk_label,
+        )
+        self.codes = bpe_settings.bpe_codes
+        self.seq_postfix = seq_postfix
+        self.use_unk_label = use_unk_label
+
+    def register_outputs(self, prefix):
+        tk.register_output("%s.codes" % prefix, self.codes)
+        tk.register_output("%s.vocab" % prefix, self.vocab)
+
+    def as_returnn_targets_opts(self):
+        opts = {
+            "class": "BytePairEncoding",
+            "bpe_file": self.codes,
+            "vocab_file": self.vocab,
+            "unknown_label": self.unk_label if self.use_unk_label else None,
+        }
+        if self.seq_postfix is not None:
+            opts["seq_postfix"] = [self.seq_postfix]
+        return opts
+
+
+class SentencePieceDatastream(Datastream):
+    """
+    Defines a label datastream for sentence-pieces. This does not inherit from LabelDatastream as it uses
+    """
+
+    def __init__(self, available_for_inference, spm_model, vocab_size):
+        super().__init__(available_for_inference)
+        self.vocab_size = vocab_size
+        self.spm_model = spm_model
+
+    def as_returnn_extern_data_opts(self, available_for_inference: Optional[bool] = None, **kwargs) -> Dict[str, Any]:
+        """
+        :param tk.Variable|int vocab_size: number of labels
+        :rtype: dict[str]
+        """
+        d = {
+            **super().as_returnn_extern_data_opts(available_for_inference=available_for_inference),
+            "shape": (None,),
+            "dim": self.vocab_size,
+            "sparse": True,
+        }
+        d.update(kwargs)
+        return d
+
+    def as_returnn_targets_opts(self):
+        opts = {
+            "class": "SentencePieces",
+            "model_file": self.spm_model,
+            "add_eos": True,
+        }
+        return opts

--- a/common/setups/returnn/datastreams/vocabulary.py
+++ b/common/setups/returnn/datastreams/vocabulary.py
@@ -88,7 +88,7 @@ class BpeDatastream(LabelDatastream):
     ):
         """
         :param bpe_settings: object from the common BPE helpers
-        :param seq_postfix:
+        :param seq_postfix: label index for the label to add at the end of each sequence
         :param bool use_unk_label: unk_label should never be used for training
         """
         super(BpeDatastream, self).__init__(


### PR DESCRIPTION
This is the last remaining component of my usual setups which is not pushed yet. Some parts are maybe not too relevant, now that we are often not doing feature extraction with librosa but mostly in the graph. Still, it can be used to compute features statistics that exactly match the ones computed by the PyTorch feature extraction. 

It also makes it transparent in the recipes what features we actually support in RETURNN. 

Mostly relevant for @Atticus1806 but I marked other that also could find this interesting.