### PR TITLE
Fix add_global_statistics

### DIFF
--- a/common/setups/returnn/datastreams/audio.py
+++ b/common/setups/returnn/datastreams/audio.py
@@ -95,7 +95,7 @@ class ReturnnAudioFeatureOptions:
     feature_options: Optional[Union[dict, AdditionalFeatureOptions]] = None
     sample_rate: Optional[int] = None
     peak_normalization: bool = True
-    preemphasis: float = None
+    preemphasis: Optional[float] = None
 
     def __post_init__(self):
         # convert Enum back to str
@@ -198,7 +198,7 @@ class AudioFeatureDatastream(Datastream):
         :rtype: AudioFeatureDatastream
         """
         extraction_dataset = OggZipDataset(
-            path=zip_datasets,
+            files=zip_datasets,
             segment_file=segment_file,
             audio_options=self.as_returnn_audio_opts(),
             target_options=None,


### PR DESCRIPTION
The call was still wrong after changes to the OggZipDataset were made before moving it to `common`

It seems other people using this pipeline still use code from my user, but I guess the statistics part is only used for TTS.

