### PR TITLE
GenericSeq2SeqSearchJob: fix feature flow outputs

### DIFF
--- a/users/berger/recipe/recognition/generic_seq2seq_search.py
+++ b/users/berger/recipe/recognition/generic_seq2seq_search.py
@@ -330,6 +330,9 @@ class GenericSeq2SeqSearchJob(rasr.RasrCommand, Job):
 
         # feature flow #
         config.flf_lattice_tool.network.recognizer.feature_extraction.file = "feature.flow"
+        if feature_flow.outputs != {"features"}:
+            assert len(feature_flow.outputs) == 1, "not implemented otherwise"
+            config.flf_lattice_tool.network.recognizer.feature_extraction.main_port_name = list(feature_flow.outputs)[0]
         feature_flow.apply_config(
             "flf-lattice-tool.network.recognizer.feature-extraction",
             config,


### PR DESCRIPTION
Hi Simon, I have a recognition with a samples feature flow. There, the feature flow output is called `"samples"` instead of `"features"` which needs to be set explicitly in the recognition config. I thought it would be easiest to do this in the job instead of always having to hack it into the config from outside.