### PR TITLE
Implemented ulaw for audio perturbation

### DIFF
--- a/users/vieting/experiments/switchboard/ctc/feat/network_helpers/perturbation.py
+++ b/users/vieting/experiments/switchboard/ctc/feat/network_helpers/perturbation.py
@@ -73,7 +73,9 @@ class WaveformPerturbation:
         if codecs:
             self._perturbations.append(functools.partial(self.apply_codecs, codecs=codecs))
         if non_linearity:
-            self._perturbations.append(functools.partial(self.non_linearity_function, factor=PerturbationFactor(**non_linearity)))
+            self._perturbations.append(
+                functools.partial(self.non_linearity_function, factor=PerturbationFactor(**non_linearity))
+            )
 
     def run(self, audio, sample_rate, random_state):
         import numpy as np
@@ -126,8 +128,8 @@ class WaveformPerturbation:
             prob = codec.pop("prob", 1.0)
             if random_state.random() < prob:
                 if codec.get("encoding") == "ULAW":
-                    #standard values for µ-law encoding
-                    quantization_bits=8
+                    # standard values for µ-law encoding
+                    quantization_bits = 8
                     MU = 255.0
 
                     # ensure audio is normalised
@@ -138,9 +140,11 @@ class WaveformPerturbation:
                     encoded_audio = np.sign(normalized_audio) * np.log1p(MU * np.abs(normalized_audio)) / np.log1p(MU)
                     encoded_audio = ((encoded_audio + 1) / 2 * (2**quantization_bits - 1)).astype(np.float64)
 
-                    #normalise encoded audio
-                    encoded_normalized_audio = (encoded_audio - encoded_audio.min()) / (encoded_audio.max() - encoded_audio.min())
-    
+                    # normalise encoded audio
+                    encoded_normalized_audio = (encoded_audio - encoded_audio.min()) / (
+                        encoded_audio.max() - encoded_audio.min()
+                    )
+
                     output_audio = encoded_normalized_audio
                 else:
                     raise NotImplementedError(f"Codec {codec} not implemented.")

--- a/users/vieting/experiments/switchboard/ctc/feat/network_helpers/perturbation.py
+++ b/users/vieting/experiments/switchboard/ctc/feat/network_helpers/perturbation.py
@@ -130,7 +130,7 @@ class WaveformPerturbation:
                 if codec.get("encoding") == "ULAW":
                     # standard values for µ-law encoding
                     quantization_bits = 8
-                    MU = 255.0
+                    mu = 255.0
 
                     # ensure audio is normalised
                     max_amplitude = np.max(np.abs(output_audio))

--- a/users/vieting/experiments/switchboard/ctc/feat/network_helpers/perturbation.py
+++ b/users/vieting/experiments/switchboard/ctc/feat/network_helpers/perturbation.py
@@ -123,7 +123,6 @@ class WaveformPerturbation:
 
     @staticmethod
     def apply_codecs(audio, sample_rate, random_state, codecs):
-        output_audio = audio
         for codec in codecs:
             prob = codec.pop("prob", 1.0)
             if random_state.random() < prob:
@@ -132,12 +131,8 @@ class WaveformPerturbation:
                     quantization_bits = 8
                     mu = 255.0
 
-                    # ensure audio is normalised
-                    max_amplitude = np.max(np.abs(output_audio))
-                    normalized_audio = audio / max_amplitude
-
-                    # µ-law encoding formula
-                    encoded_audio = np.sign(normalized_audio) * np.log1p(MU * np.abs(normalized_audio)) / np.log1p(MU)
+                    # mu-law encoding formula
+                    encoded_audio = np.sign(audio) * np.log1p(mu * np.abs(audio)) / np.log1p(mu)
                     encoded_audio = ((encoded_audio + 1) / 2 * (2**quantization_bits - 1)).astype(np.float64)
 
                     # normalize encoded audio
@@ -145,7 +140,7 @@ class WaveformPerturbation:
                         encoded_audio.max() - encoded_audio.min()
                     )
 
-                    output_audio = encoded_normalized_audio
+                    audio = encoded_normalized_audio
                 else:
                     raise NotImplementedError(f"Codec {codec} not implemented.")
         return output_audio

--- a/users/vieting/experiments/switchboard/ctc/feat/network_helpers/perturbation.py
+++ b/users/vieting/experiments/switchboard/ctc/feat/network_helpers/perturbation.py
@@ -127,7 +127,7 @@ class WaveformPerturbation:
             prob = codec.pop("prob", 1.0)
             if random_state.random() < prob:
                 if codec.get("encoding") == "ULAW":
-                    # check if youdio is in the right range for mu-law encoding
+                    # check if audio is in the right range for mu-law encoding
                     if np.max(np.abs(audio)) > 1.0:
                         raise ValueError("Audio must be in the range [-1, 1] for mu-law encoding.")
                     # standard value for mu-law encoding

--- a/users/vieting/experiments/switchboard/ctc/feat/network_helpers/perturbation.py
+++ b/users/vieting/experiments/switchboard/ctc/feat/network_helpers/perturbation.py
@@ -140,7 +140,7 @@ class WaveformPerturbation:
                     encoded_audio = np.sign(normalized_audio) * np.log1p(MU * np.abs(normalized_audio)) / np.log1p(MU)
                     encoded_audio = ((encoded_audio + 1) / 2 * (2**quantization_bits - 1)).astype(np.float64)
 
-                    # normalise encoded audio
+                    # normalize encoded audio
                     encoded_normalized_audio = (encoded_audio - encoded_audio.min()) / (
                         encoded_audio.max() - encoded_audio.min()
                     )

--- a/users/vieting/experiments/switchboard/ctc/feat/network_helpers/perturbation.py
+++ b/users/vieting/experiments/switchboard/ctc/feat/network_helpers/perturbation.py
@@ -130,13 +130,10 @@ class WaveformPerturbation:
                     # check if youdio is in the right range for mu-law encoding
                     if np.max(np.abs(audio)) > 1.0:
                         raise ValueError("Audio must be in the range [-1, 1] for mu-law encoding.")
-
                     # standard value for mu-law encoding
                     mu = 255.0
-
                     # mu-law encoding formula
-                    encoded_audio = np.sign(audio) * np.log1p(mu * np.abs(audio)) / np.log1p(mu)
-                    audio = encoded_audio
+                    audio = np.sign(audio) * np.log1p(mu * np.abs(audio)) / np.log1p(mu)
                 else:
                     raise NotImplementedError(f"Codec {codec} not implemented.")
         return audio

--- a/users/vieting/experiments/switchboard/ctc/feat/network_helpers/perturbation.py
+++ b/users/vieting/experiments/switchboard/ctc/feat/network_helpers/perturbation.py
@@ -135,10 +135,7 @@ class WaveformPerturbation:
                     encoded_audio = np.sign(audio) * np.log1p(mu * np.abs(audio)) / np.log1p(mu)
                     encoded_audio = ((encoded_audio + 1) / 2 * (2**quantization_bits - 1)).astype(np.float64)
 
-                    # normalize encoded audio to -1 to 1
-                    encoded_normalized_audio = (encoded_audio / (2**quantization_bits - 1) * 2) - 1
-
-                    audio = encoded_normalized_audio
+                    audio = encoded_audio
                 else:
                     raise NotImplementedError(f"Codec {codec} not implemented.")
         return audio

--- a/users/vieting/experiments/switchboard/ctc/feat/network_helpers/perturbation.py
+++ b/users/vieting/experiments/switchboard/ctc/feat/network_helpers/perturbation.py
@@ -127,6 +127,10 @@ class WaveformPerturbation:
             prob = codec.pop("prob", 1.0)
             if random_state.random() < prob:
                 if codec.get("encoding") == "ULAW":
+                    # check if youdio is in the right range for mu-law encoding
+                    if np.max(np.abs(audio)) > 1.0:
+                        raise ValueError("Audio must be in the range [-1, 1] for mu-law encoding.")
+
                     # standard value for mu-law encoding
                     mu = 255.0
 

--- a/users/vieting/experiments/switchboard/ctc/feat/network_helpers/perturbation.py
+++ b/users/vieting/experiments/switchboard/ctc/feat/network_helpers/perturbation.py
@@ -127,7 +127,7 @@ class WaveformPerturbation:
             prob = codec.pop("prob", 1.0)
             if random_state.random() < prob:
                 if codec.get("encoding") == "ULAW":
-                    # standard values for µ-law encoding
+                    # standard values for mu-law encoding
                     quantization_bits = 8
                     mu = 255.0
 

--- a/users/vieting/experiments/switchboard/ctc/feat/network_helpers/perturbation.py
+++ b/users/vieting/experiments/switchboard/ctc/feat/network_helpers/perturbation.py
@@ -135,10 +135,8 @@ class WaveformPerturbation:
                     encoded_audio = np.sign(audio) * np.log1p(mu * np.abs(audio)) / np.log1p(mu)
                     encoded_audio = ((encoded_audio + 1) / 2 * (2**quantization_bits - 1)).astype(np.float64)
 
-                    # normalize encoded audio
-                    encoded_normalized_audio = (encoded_audio - encoded_audio.min()) / (
-                        encoded_audio.max() - encoded_audio.min()
-                    )
+                    # normalize encoded audio to -1 to 1
+                    encoded_normalized_audio = (encoded_audio / (2**quantization_bits - 1) * 2) - 1
 
                     audio = encoded_normalized_audio
                 else:

--- a/users/vieting/experiments/switchboard/ctc/feat/network_helpers/perturbation.py
+++ b/users/vieting/experiments/switchboard/ctc/feat/network_helpers/perturbation.py
@@ -136,8 +136,6 @@ class WaveformPerturbation:
 
                     # mu-law encoding formula
                     encoded_audio = np.sign(audio) * np.log1p(mu * np.abs(audio)) / np.log1p(mu)
-                    encoded_audio = ((encoded_audio + 1) / 2 * 255).astype(np.float32)
-
                     audio = encoded_audio
                 else:
                     raise NotImplementedError(f"Codec {codec} not implemented.")

--- a/users/vieting/experiments/switchboard/ctc/feat/network_helpers/perturbation.py
+++ b/users/vieting/experiments/switchboard/ctc/feat/network_helpers/perturbation.py
@@ -127,13 +127,12 @@ class WaveformPerturbation:
             prob = codec.pop("prob", 1.0)
             if random_state.random() < prob:
                 if codec.get("encoding") == "ULAW":
-                    # standard values for mu-law encoding
-                    quantization_bits = 8
+                    # standard value for mu-law encoding
                     mu = 255.0
 
                     # mu-law encoding formula
                     encoded_audio = np.sign(audio) * np.log1p(mu * np.abs(audio)) / np.log1p(mu)
-                    encoded_audio = ((encoded_audio + 1) / 2 * (2**quantization_bits - 1)).astype(np.float64)
+                    encoded_audio = ((encoded_audio + 1) / 2 * 255).astype(np.float32)
 
                     audio = encoded_audio
                 else:

--- a/users/vieting/experiments/switchboard/ctc/feat/network_helpers/perturbation.py
+++ b/users/vieting/experiments/switchboard/ctc/feat/network_helpers/perturbation.py
@@ -143,7 +143,7 @@ class WaveformPerturbation:
                     audio = encoded_normalized_audio
                 else:
                     raise NotImplementedError(f"Codec {codec} not implemented.")
-        return output_audio
+        return audio
 
     @staticmethod
     def non_linearity_function(audio, sample_rate, random_state, factor):


### PR DESCRIPTION
The implementation follows the standard u-law encoding and sounds identical to the torchaudio implementation. 
The values however are not identical to the torchaudio output. When normalized. the values differ up to 0.02. 