### PR TITLE
Remove audio perturbation arguments from recognition configuration

### DIFF
--- a/users/vieting/experiments/switchboard/ctc/feat/baseline_args.py
+++ b/users/vieting/experiments/switchboard/ctc/feat/baseline_args.py
@@ -196,7 +196,7 @@ def get_returnn_config(
     )
 
     if audio_perturbation and not recognition:
-        prolog += get_code_for_perturbation()   
+        prolog += get_code_for_perturbation()
     for layer in list(network.keys()):
         if network[layer]["from"] == "data":
             network[layer]["from"] = "features"

--- a/users/vieting/experiments/switchboard/ctc/feat/baseline_args.py
+++ b/users/vieting/experiments/switchboard/ctc/feat/baseline_args.py
@@ -100,6 +100,14 @@ def get_nn_args_single(
         **(returnn_args or {}),
     )
 
+    recog_args = returnn_args.copy() if returnn_args else {}
+
+    if "extra_args" in recog_args:
+        if "audio_perturb_args" in recog_args["extra_args"]:
+            del recog_args["extra_args"]["audio_perturb_args"]
+        if "audio_perturb_runner" in recog_args["extra_args"]:
+            del recog_args["extra_args"]["audio_perturb_runner"]
+
     returnn_recog_config = get_returnn_config(
         num_inputs=1,
         num_outputs=num_outputs,
@@ -107,7 +115,7 @@ def get_nn_args_single(
         recognition=True,
         num_epochs=num_epochs,
         feature_net=feature_net,
-        **(returnn_args or {}),
+        **(recog_args or {}),
     )
 
     report_args = {
@@ -197,6 +205,8 @@ def get_returnn_config(
 
     if audio_perturbation:
         prolog += get_code_for_perturbation()
+        if recognition and "pre_process" in datasets["dev"]["audio"]:
+            del datasets["dev"]["audio"]["pre_process"]
     for layer in list(network.keys()):
         if network[layer]["from"] == "data":
             network[layer]["from"] = "features"

--- a/users/vieting/experiments/switchboard/ctc/feat/baseline_args.py
+++ b/users/vieting/experiments/switchboard/ctc/feat/baseline_args.py
@@ -196,8 +196,7 @@ def get_returnn_config(
     )
 
     if audio_perturbation and not recognition:
-        prolog += get_code_for_perturbation()
-        
+        prolog += get_code_for_perturbation()   
     for layer in list(network.keys()):
         if network[layer]["from"] == "data":
             network[layer]["from"] = "features"

--- a/users/vieting/experiments/switchboard/ctc/feat/baseline_args.py
+++ b/users/vieting/experiments/switchboard/ctc/feat/baseline_args.py
@@ -100,8 +100,6 @@ def get_nn_args_single(
         **(returnn_args or {}),
     )
 
-    recog_args = returnn_args.copy() if returnn_args else {}
-
     returnn_recog_config = get_returnn_config(
         num_inputs=1,
         num_outputs=num_outputs,
@@ -109,7 +107,7 @@ def get_nn_args_single(
         recognition=True,
         num_epochs=num_epochs,
         feature_net=feature_net,
-        **(recog_args or {}),
+        **(returnn_args or {}),
     )
 
     report_args = {

--- a/users/vieting/experiments/switchboard/ctc/feat/baseline_args.py
+++ b/users/vieting/experiments/switchboard/ctc/feat/baseline_args.py
@@ -197,7 +197,7 @@ def get_returnn_config(
         recognition=recognition,
     )
 
-    if audio_perturbation and not recognition::
+    if audio_perturbation and not recognition:
         prolog += get_code_for_perturbation()
         
     for layer in list(network.keys()):
@@ -209,7 +209,7 @@ def get_returnn_config(
     network["features"] = feature_net
     if recognition:
 
-        if  "pre_process" in datasets["dev"]["audio"]:
+        if "pre_process" in datasets["dev"]["audio"]:
             del datasets["dev"]["audio"]["pre_process"]
 
         extra_args.pop("audio_parturb_args", None)

--- a/users/vieting/experiments/switchboard/ctc/feat/baseline_args.py
+++ b/users/vieting/experiments/switchboard/ctc/feat/baseline_args.py
@@ -205,7 +205,6 @@ def get_returnn_config(
             network[layer]["from"] = "features"
     network["features"] = feature_net
     if recognition:
-
         if "pre_process" in datasets["dev"]["audio"]:
             del datasets["dev"]["audio"]["pre_process"]
 

--- a/users/vieting/experiments/switchboard/ctc/feat/baseline_args.py
+++ b/users/vieting/experiments/switchboard/ctc/feat/baseline_args.py
@@ -102,12 +102,6 @@ def get_nn_args_single(
 
     recog_args = returnn_args.copy() if returnn_args else {}
 
-    if "extra_args" in recog_args:
-        if "audio_perturb_args" in recog_args["extra_args"]:
-            del recog_args["extra_args"]["audio_perturb_args"]
-        if "audio_perturb_runner" in recog_args["extra_args"]:
-            del recog_args["extra_args"]["audio_perturb_runner"]
-
     returnn_recog_config = get_returnn_config(
         num_inputs=1,
         num_outputs=num_outputs,
@@ -203,10 +197,9 @@ def get_returnn_config(
         recognition=recognition,
     )
 
-    if audio_perturbation:
+    if audio_perturbation and not recognition::
         prolog += get_code_for_perturbation()
-        if recognition and "pre_process" in datasets["dev"]["audio"]:
-            del datasets["dev"]["audio"]["pre_process"]
+        
     for layer in list(network.keys()):
         if network[layer]["from"] == "data":
             network[layer]["from"] = "features"
@@ -215,6 +208,13 @@ def get_returnn_config(
             network[layer]["from"] = "features"
     network["features"] = feature_net
     if recognition:
+
+        if  "pre_process" in datasets["dev"]["audio"]:
+            del datasets["dev"]["audio"]["pre_process"]
+
+        extra_args.pop("audio_parturb_args", None)
+        extra_args.pop("audio_parturb_runner", None)
+
         for layer in list(network.keys()):
             if "aux" in layer:
                 network.pop(layer)

--- a/users/vieting/experiments/switchboard/ctc/feat/baseline_args.py
+++ b/users/vieting/experiments/switchboard/ctc/feat/baseline_args.py
@@ -205,9 +205,7 @@ def get_returnn_config(
             network[layer]["from"] = "features"
     network["features"] = feature_net
     if recognition:
-        if "pre_process" in datasets["dev"]["audio"]:
-            del datasets["dev"]["audio"]["pre_process"]
-
+        datasets["dev"]["audio"].pop("pre_process", None)
         extra_args.pop("audio_parturb_args", None)
         extra_args.pop("audio_parturb_runner", None)
 


### PR DESCRIPTION
Perturbation arguments have to be removed for the recognition config.  