### PR TITLE
Improved ModelConfiguration serialization

### DIFF
--- a/common/setups/returnn_pytorch/serialization.py
+++ b/common/setups/returnn_pytorch/serialization.py
@@ -255,7 +255,9 @@ def build_config_constructor_serializers(
 
 
 def build_config_constructor_serializers_v2(
-    cfg: ModelConfiguration, variable_name: Optional[str] = None, unhashed_package_root: Optional[str] = None
+    cfg: ModelConfiguration,
+    variable_name: Optional[str] = None,
+    unhashed_package_root: Optional[str] = None,
 ) -> Tuple[Call, List[Import]]:
     """
     Creates a Call object that will re-construct the given ModelConfiguration when serialized and
@@ -307,7 +309,10 @@ def build_config_constructor_serializers_v2(
             return (
                 Call(
                     callable_name=ModuleFactoryV1.__name__,
-                    kwargs=[("module_class", value.module_class.__name__), ("cfg", subcall)],
+                    kwargs=[
+                        ("module_class", value.module_class.__name__),
+                        ("cfg", subcall),
+                    ],
                 ),
                 subimports,
             )
@@ -389,7 +394,8 @@ def build_config_constructor_serializers_v2(
     # Import the class of `cfg`
     imports = [
         Import(
-            code_object_path=f"{type(cfg).__module__}.{type(cfg).__name__}", unhashed_package_root=unhashed_package_root
+            code_object_path=f"{type(cfg).__module__}.{type(cfg).__name__}",
+            unhashed_package_root=unhashed_package_root,
         )
     ]
 
@@ -413,5 +419,13 @@ def build_config_constructor_serializers_v2(
             seen_hashes.add(imp_hash)
             unique_imports.append(imp)
 
-    return Call(callable_name=type(cfg).__name__, kwargs=call_kwargs, return_assign_variables=variable_name), unique_imports
+    unique_imports.sort(key=lambda imp: str(imp))
 
+    return (
+        Call(
+            callable_name=type(cfg).__name__,
+            kwargs=call_kwargs,
+            return_assign_variables=variable_name,
+        ),
+        unique_imports,
+    )

--- a/common/setups/returnn_pytorch/serialization.py
+++ b/common/setups/returnn_pytorch/serialization.py
@@ -253,16 +253,6 @@ def build_config_constructor_serializers(
 
     return Call(callable_name=type(cfg).__name__, kwargs=call_kwargs, return_assign_variables=variable_name), imports
 
-def deduplicate_list_by_hash(orig_list: list) -> list:
-    seen_hashes = set()
-    unique_objects = []
-    for obj in orig_list:
-        obj_hash = hash(obj)
-        if obj_hash not in seen_hashes:
-            seen_hashes.add(obj_hash)
-            unique_objects.append(obj)
-    return unique_objects
-
 
 def build_config_constructor_serializers_v2(
     cfg: ModelConfiguration, variable_name: Optional[str] = None, unhashed_package_root: Optional[str] = None


### PR DESCRIPTION
This PR adds a new version of the `build_config_constructor_serializers` function. Compared to the previous one, now also `Enum` values as well as `list`, `tuple` and `dict` values with non-primitive elements inside are serialized. This is useful for example for the `GenericFrontendV1` which use a sequence of `FrontendLayerType` enum values for the layer ordering. This wouldn't work with the original function but is possible with the `v2` version.

Another change is that the de-duplication of the recognized imports now works properly and imports get sorted.

The changes are realized in a `v2` function because they can affect the hash of the serializer objects and thus would break existing setups.