### PR TITLE
Recipes for w2v pretraining with positive sampling 

### DIFF
--- a/users/vieting/experiments/librispeech/librispeech_960_pretraining/wav2vec2/config_02_fairseq_phoneme.py
+++ b/users/vieting/experiments/librispeech/librispeech_960_pretraining/wav2vec2/config_02_fairseq_phoneme.py
@@ -162,8 +162,42 @@ def run_fairseq_pretraining_phoneme_negatives_other_target_boundary_masking():
     tk.register_output(f"{prefix_name}/{exp_name}/pretraining/scores.png", job.out_plot_se)
     return job
 
+def run_fairseq_pretraining_positive_sampling(num_positives: int = 10):
+    prefix_name = "experiments/librispeech/librispeech_960_pretraining/wav2vec2/"
+    alignment = get_alignment_hdf()
+    num_gpus = 8
+    fairseq_python_exe = tk.Path(
+        "/home/pv653172/setups/librispeech/20230328_wav2vec2/dependencies/python_launcher.sh",
+        hash_overwrite="itc_python_launcher_py310_torch",
+    )
+    fairseq_root = get_fairseq_root(fairseq_exe=fairseq_python_exe)
+    fairseq_training_args = dict(
+        save_interval=25,
+        max_epoch=600,
+        max_update=420000,
+        fairseq_root=fairseq_root,
+        fairseq_python_exe=fairseq_python_exe,
+        rqmt={"time": 120, "mem": 12, "cpu": 2, "gpu": num_gpus},
+    )
+
+    # run pre-training
+    exp_name = f"monophone_positive_sampling_{num_positives}_v1"
+    fairseq_args = get_fairseq_args(num_gpus=num_gpus)
+    fairseq_args["task"]["alignment"] = alignment
+    fairseq_args["model"]["num_positives"] = num_positives
+    fairseq_root = get_fairseq_root(fairseq_exe=fairseq_python_exe, commit="654cd1e65473615f3355a2576adbaba5f5b549c2")
+    fairseq_training_args["fairseq_root"] = fairseq_root
+    fairseq_config = FairseqHydraConfig(fairseq_args)
+    job = FairseqHydraTrainingJob(fairseq_config, **fairseq_training_args)
+    job.add_alias(os.path.join(prefix_name, exp_name, "pretraining"))
+    tk.register_output(f"{prefix_name}/{exp_name}/pretraining/scores.png", job.out_plot_se)
+    return job    
 
 def py():
     run_fairseq_pretraining_negatives_other_target()
     run_fairseq_pretraining_phoneme_boundary_masking()
     run_fairseq_pretraining_phoneme_negatives_other_target_boundary_masking()
+    run_fairseq_pretraining_positive_sampling(num_positives=5)
+    run_fairseq_pretraining_positive_sampling(num_positives=10)
+    run_fairseq_pretraining_positive_sampling(num_positives=15)
+

--- a/users/vieting/experiments/librispeech/librispeech_960_pretraining/wav2vec2/config_02_fairseq_phoneme.py
+++ b/users/vieting/experiments/librispeech/librispeech_960_pretraining/wav2vec2/config_02_fairseq_phoneme.py
@@ -72,7 +72,7 @@ def run_fairseq_pretraining_negatives_other_target():
         fairseq_python_exe = tk.Path(itc_python_launcher, hash_overwrite="itc_python_launcher_py310_torch")
     else:
         fairseq_python_exe = tk.Path("/usr/bin/python3", hash_overwrite="itc_python_launcher_py310_torch")
-    fairseq_root = get_fairseq_root(fairseq_exe=fairseq_python_exe)
+    fairseq_root = get_fairseq_root(fairseq_exe=fairseq_python_exe, commit="1397363c5c0e3c4e3ab620be562730399c852493")
     fairseq_training_args = dict(
         save_interval=25,
         max_epoch=600,
@@ -87,7 +87,6 @@ def run_fairseq_pretraining_negatives_other_target():
     fairseq_args = get_fairseq_args(num_gpus=num_gpus)
     fairseq_args["task"]["alignment"] = alignment
     fairseq_args["model"]["negative_sampling_strategy"] = "other_target"
-    fairseq_root = get_fairseq_root(fairseq_exe=fairseq_python_exe, commit="1397363c5c0e3c4e3ab620be562730399c852493")
     fairseq_training_args["fairseq_root"] = fairseq_root
     fairseq_config = FairseqHydraConfig(fairseq_args)
     job = FairseqHydraTrainingJob(fairseq_config, **fairseq_training_args)
@@ -104,7 +103,7 @@ def run_fairseq_pretraining_phoneme_boundary_masking():
         "/home/pv653172/setups/librispeech/20230328_wav2vec2/dependencies/python_launcher.sh",
         hash_overwrite="itc_python_launcher_py310_torch",
     )
-    fairseq_root = get_fairseq_root(fairseq_exe=fairseq_python_exe)
+    fairseq_root = get_fairseq_root(fairseq_exe=fairseq_python_exe, commit="b768be5b81987364d39a07d1caad2bfe1e956896")
     fairseq_training_args = dict(
         save_interval=25,
         max_epoch=600,
@@ -120,7 +119,6 @@ def run_fairseq_pretraining_phoneme_boundary_masking():
     fairseq_args["task"]["alignment"] = alignment
     fairseq_args["model"]["mask_strategy"] = "phoneme"
     fairseq_args["model"]["mask_length"] = 1
-    fairseq_root = get_fairseq_root(fairseq_exe=fairseq_python_exe, commit="b768be5b81987364d39a07d1caad2bfe1e956896")
     fairseq_training_args["fairseq_root"] = fairseq_root
     fairseq_config = FairseqHydraConfig(fairseq_args)
     job = FairseqHydraTrainingJob(fairseq_config, **fairseq_training_args)
@@ -137,7 +135,7 @@ def run_fairseq_pretraining_phoneme_negatives_other_target_boundary_masking():
         "/home/pv653172/setups/librispeech/20230328_wav2vec2/dependencies/python_launcher.sh",
         hash_overwrite="itc_python_launcher_py310_torch",
     )
-    fairseq_root = get_fairseq_root(fairseq_exe=fairseq_python_exe)
+    fairseq_root = get_fairseq_root(fairseq_exe=fairseq_python_exe, commit="b768be5b81987364d39a07d1caad2bfe1e956896")
     fairseq_training_args = dict(
         save_interval=25,
         max_epoch=600,
@@ -154,7 +152,6 @@ def run_fairseq_pretraining_phoneme_negatives_other_target_boundary_masking():
     fairseq_args["model"]["negative_sampling_strategy"] = "other_target"
     fairseq_args["model"]["mask_strategy"] = "phoneme"
     fairseq_args["model"]["mask_length"] = 1
-    fairseq_root = get_fairseq_root(fairseq_exe=fairseq_python_exe, commit="b768be5b81987364d39a07d1caad2bfe1e956896")
     fairseq_training_args["fairseq_root"] = fairseq_root
     fairseq_config = FairseqHydraConfig(fairseq_args)
     job = FairseqHydraTrainingJob(fairseq_config, **fairseq_training_args)
@@ -170,7 +167,7 @@ def run_fairseq_pretraining_positive_sampling(num_positives: int = 10):
         "/home/pv653172/setups/librispeech/20230328_wav2vec2/dependencies/python_launcher.sh",
         hash_overwrite="itc_python_launcher_py310_torch",
     )
-    fairseq_root = get_fairseq_root(fairseq_exe=fairseq_python_exe)
+    fairseq_root = get_fairseq_root(fairseq_exe=fairseq_python_exe, commit="654cd1e65473615f3355a2576adbaba5f5b549c2")
     fairseq_training_args = dict(
         save_interval=25,
         max_epoch=600,
@@ -185,8 +182,6 @@ def run_fairseq_pretraining_positive_sampling(num_positives: int = 10):
     fairseq_args = get_fairseq_args(num_gpus=num_gpus)
     fairseq_args["task"]["alignment"] = alignment
     fairseq_args["model"]["num_positives"] = num_positives
-    fairseq_root = get_fairseq_root(fairseq_exe=fairseq_python_exe, commit="654cd1e65473615f3355a2576adbaba5f5b549c2")
-    fairseq_training_args["fairseq_root"] = fairseq_root
     fairseq_config = FairseqHydraConfig(fairseq_args)
     job = FairseqHydraTrainingJob(fairseq_config, **fairseq_training_args)
     job.add_alias(os.path.join(prefix_name, exp_name, "pretraining"))


### PR DESCRIPTION
I added the first few recipes for pretraining w2v with positive samples.

In my opinion, we should first run the pretraining with only positive samples (i.e. no other modifications) to find out the ideal value for `num_positive_samples`, after that, we should combine the positive sampling with the other modifications and use the corresponding `num_positive_samples` value. 

This is debatable however, I'm open to changing the order of experiments as well.