### PR TITLE
Refactoring w2v phoneme pretrain config

### DIFF
--- a/users/vieting/experiments/librispeech/librispeech_960_pretraining/wav2vec2/config_02_fairseq_phoneme.py
+++ b/users/vieting/experiments/librispeech/librispeech_960_pretraining/wav2vec2/config_02_fairseq_phoneme.py
@@ -63,20 +63,23 @@ def get_fairseq_root(commit="e4a2e4e93efbcbaaae52a17ae6600beb2083fb33", fairseq_
     return fairseq_root
 
 
-def run_fairseq_pretraining(exp_name, commit, **kwargs):
+def run_fairseq_pretraining(exp_name, commit, python_exe_hash_overwrite=None, **kwargs):
     """
     Runs a FairseqHydraTrainingJob to pretrain a wav2vec 2.0 model.
 
     Args:
-        exp_name: The name of the experiment, used for output and alias folder.
-        commit: The commit ID of the fairseq_phoneme repository to use.
+        exp_name (str): The name of the experiment, used for output and alias folder.
+        commit (str): The commit ID of the fairseq_phoneme repository to use.
+        python_exe_hash_overwrite (Optional[str]): The hash overwrite for the fairseq_python_exe to use.
+            It should only be used to achieve compatibility with the previous setup structure and should be ignored
+            in all other cases.
         **kwargs: Additional arguments to pass to the job. These will be used to overwrite the model configuration.
     """
     # job requirements
     prefix_name = "experiments/librispeech/librispeech_960_pretraining/wav2vec2/"
     alignment = get_alignment_hdf()
     num_gpus = 8
-    fairseq_python_exe = tk.Path("/usr/bin/python3") # maybe add: hash_overwrite="itc_python_launcher_py310_torch"?
+    fairseq_python_exe = tk.Path("/usr/bin/python3", hash_overwrite=python_exe_hash_overwrite) # maybe add: hash_overwrite="itc_python_launcher_py310_torch"?
     fairseq_root = get_fairseq_root(fairseq_exe=fairseq_python_exe, commit=commit)
     fairseq_training_args = dict(
         save_interval=25,
@@ -106,18 +109,21 @@ def py():
     run_fairseq_pretraining(
         exp_name="monophone_negatives_other_target_v1",
         commit="1397363c5c0e3c4e3ab620be562730399c852493",
+        python_exe_hash_overwrite="itc_python_launcher_py310_torch",
         negative_sampling_strategy="other_target",
     )
     # negatives hard
     run_fairseq_pretraining(
         exp_name="monophone_negatives_hard_v1",
         commit="56acedca3b72c09ec30b7208da0d15ada03d0479",
+        python_exe_hash_overwrite="itc_python_launcher_py310_torch",
         negative_sampling_strategy="hard_negatives",
     )
     # boundary_masking
     run_fairseq_pretraining(
         exp_name="monophone_boundary_masking_v1",
         commit="b768be5b81987364d39a07d1caad2bfe1e956896",
+        python_exe_hash_overwrite="itc_python_launcher_py310_torch",
         mask_strategy="phoneme",
         mask_length=1,
     )

--- a/users/vieting/experiments/librispeech/librispeech_960_pretraining/wav2vec2/config_02_fairseq_phoneme.py
+++ b/users/vieting/experiments/librispeech/librispeech_960_pretraining/wav2vec2/config_02_fairseq_phoneme.py
@@ -79,7 +79,7 @@ def run_fairseq_pretraining(exp_name, commit, python_exe_hash_overwrite=None, **
     prefix_name = "experiments/librispeech/librispeech_960_pretraining/wav2vec2/"
     alignment = get_alignment_hdf()
     num_gpus = 8
-    fairseq_python_exe = tk.Path("/usr/bin/python3", hash_overwrite=python_exe_hash_overwrite) # maybe add: hash_overwrite="itc_python_launcher_py310_torch"?
+    fairseq_python_exe = tk.Path("/usr/bin/python3", hash_overwrite=python_exe_hash_overwrite)
     fairseq_root = get_fairseq_root(fairseq_exe=fairseq_python_exe, commit=commit)
     fairseq_training_args = dict(
         save_interval=25,

--- a/users/vieting/experiments/librispeech/librispeech_960_pretraining/wav2vec2/config_02_fairseq_phoneme.py
+++ b/users/vieting/experiments/librispeech/librispeech_960_pretraining/wav2vec2/config_02_fairseq_phoneme.py
@@ -133,6 +133,6 @@ def py():
     for num_positives in [5, 10, 15]:
         run_fairseq_pretraining(
             exp_name=f"monophone_positive_sampling_{num_positives}_v1",
-            commit="654cd1e65473615f3355a2576adbaba5f5b549c2",
+            commit="91b936231c5ebbfd639ccd7e78869d3df45a12bb",
             num_positives=num_positives,
         )

--- a/users/vieting/experiments/librispeech/librispeech_960_pretraining/wav2vec2/config_02_fairseq_phoneme.py
+++ b/users/vieting/experiments/librispeech/librispeech_960_pretraining/wav2vec2/config_02_fairseq_phoneme.py
@@ -1,6 +1,7 @@
 """
 Config for pre-training experiments on LibriSpeech using wav2vec 2.0.
 """
+
 import os.path
 
 from sisyphus import tk
@@ -26,22 +27,22 @@ def get_alignment_hdf():
         if os.path.exists(dep_dir):
             dependency_dir = dep_dir
     assert dependency_dir is not None
-    alignment_caches = [tk.Path(
-        os.path.join(dependency_dir, f"alignments/monophone_10ms_gmm_fix/output/alignment.cache.{idx}"),
-        hash_overwrite=f"ls960_monophone_10ms_gmm_fix_alignment_{idx}",
-    ) for idx in range(1, 201)]
+    alignment_caches = [
+        tk.Path(
+            os.path.join(dependency_dir, f"alignments/monophone_10ms_gmm_fix/output/alignment.cache.{idx}"),
+            hash_overwrite=f"ls960_monophone_10ms_gmm_fix_alignment_{idx}",
+        )
+        for idx in range(1, 201)
+    ]
     allophone_file = tk.Path(
         os.path.join(
             dependency_dir,
-            f"alignments/monophone_10ms_gmm_fix/dependencies/StoreAllophonesJob.68JjXthmrl8y/output/allophones"
+            f"alignments/monophone_10ms_gmm_fix/dependencies/StoreAllophonesJob.68JjXthmrl8y/output/allophones",
         ),
         hash_overwrite="ls960_monophone_10ms_gmm_fix_allophones",
     )
     state_tying_file = tk.Path(
-        os.path.join(
-            dependency_dir,
-            "alignments/monophone_10ms_gmm_fix/dependencies/state-tying-map-to-single-state"
-        ),
+        os.path.join(dependency_dir, "alignments/monophone_10ms_gmm_fix/dependencies/state-tying-map-to-single-state"),
         hash_overwrite="ls960_monophone_10ms_gmm_state_tying_monophone_1",
     )
     job = RasrAlignmentDumpHDFJob(
@@ -56,141 +57,27 @@ def get_alignment_hdf():
 
 def get_fairseq_root(commit="e4a2e4e93efbcbaaae52a17ae6600beb2083fb33", fairseq_exe=None):
     fairseq_root = CloneGitRepositoryJob(
-        "git@github.com:vieting/fairseq_phoneme.git",
-        checkout_folder_name="fairseq",
-        commit=commit).out_repository
+        "git@github.com:vieting/fairseq_phoneme.git", checkout_folder_name="fairseq", commit=commit
+    ).out_repository
     fairseq_root = SetupFairseqJob(fairseq_root, python_exe=fairseq_exe).out_fairseq_root
     return fairseq_root
 
 
-def run_fairseq_pretraining_negatives_other_target():
+def run_fairseq_pretraining(exp_name, commit, **kwargs):
+    """
+    Runs a FairseqHydraTrainingJob to pretrain a wav2vec 2.0 model.
+
+    Args:
+        exp_name: The name of the experiment, used for output and alias folder.
+        commit: The commit ID of the fairseq_phoneme repository to use.
+        **kwargs: Additional arguments to pass to the job. These will be used to overwrite the model configuration.
+    """
+    # job requirements
     prefix_name = "experiments/librispeech/librispeech_960_pretraining/wav2vec2/"
     alignment = get_alignment_hdf()
     num_gpus = 8
-    itc_python_launcher = "/home/pv653172/setups/librispeech/20230328_wav2vec2/dependencies/python_launcher.sh"
-    if os.path.exists(itc_python_launcher):
-        fairseq_python_exe = tk.Path(itc_python_launcher, hash_overwrite="itc_python_launcher_py310_torch")
-    else:
-        fairseq_python_exe = tk.Path("/usr/bin/python3", hash_overwrite="itc_python_launcher_py310_torch")
-    fairseq_root = get_fairseq_root(fairseq_exe=fairseq_python_exe, commit="1397363c5c0e3c4e3ab620be562730399c852493")
-    fairseq_training_args = dict(
-        save_interval=25,
-        max_epoch=600,
-        max_update=420000,
-        fairseq_root=fairseq_root,
-        fairseq_python_exe=fairseq_python_exe,
-        rqmt={"time": 120, "mem": 12, "cpu": 2, "gpu": num_gpus},
-    )
-
-    # run pre-training
-    exp_name = "monophone_negatives_other_target_v1"
-    fairseq_args = get_fairseq_args(num_gpus=num_gpus)
-    fairseq_args["task"]["alignment"] = alignment
-    fairseq_args["model"]["negative_sampling_strategy"] = "other_target"
-    fairseq_training_args["fairseq_root"] = fairseq_root
-    fairseq_config = FairseqHydraConfig(fairseq_args)
-    job = FairseqHydraTrainingJob(fairseq_config, **fairseq_training_args)
-    job.add_alias(os.path.join(prefix_name, exp_name, "pretraining"))
-    tk.register_output(f"{prefix_name}/{exp_name}/pretraining/scores.png", job.out_plot_se)
-    return job
-
-
-def run_fairseq_pretraining_negatives_hard():
-    prefix_name = "experiments/librispeech/librispeech_960_pretraining/wav2vec2/"
-    alignment = get_alignment_hdf()
-    num_gpus = 8
-    fairseq_python_exe = tk.Path("/usr/bin/python3")
-    fairseq_root = get_fairseq_root(fairseq_exe=fairseq_python_exe, commit="56acedca3b72c09ec30b7208da0d15ada03d0479")
-    fairseq_training_args = dict(
-        save_interval=25,
-        max_epoch=600,
-        max_update=420000,
-        fairseq_root=fairseq_root,
-        fairseq_python_exe=fairseq_python_exe,
-        rqmt={"time": 120, "mem": 12, "cpu": 2, "gpu": num_gpus},
-    )
-
-    # run pre-training
-    exp_name = "monophone_negatives_hard_v1"
-    fairseq_args = get_fairseq_args(num_gpus=num_gpus)
-    fairseq_args["task"]["alignment"] = alignment
-    fairseq_args["model"]["negative_sampling_strategy"] = "hard_negatives"
-    fairseq_training_args["fairseq_root"] = fairseq_root
-    fairseq_config = FairseqHydraConfig(fairseq_args)
-    job = FairseqHydraTrainingJob(fairseq_config, **fairseq_training_args)
-    job.add_alias(os.path.join(prefix_name, exp_name, "pretraining"))
-    tk.register_output(f"{prefix_name}/{exp_name}/pretraining/scores.png", job.out_plot_se)
-    return job
-
-
-def run_fairseq_pretraining_phoneme_boundary_masking():
-    prefix_name = "experiments/librispeech/librispeech_960_pretraining/wav2vec2/"
-    alignment = get_alignment_hdf()
-    num_gpus = 8
-    fairseq_python_exe = tk.Path(
-        "/home/pv653172/setups/librispeech/20230328_wav2vec2/dependencies/python_launcher.sh",
-        hash_overwrite="itc_python_launcher_py310_torch",
-    )
-    fairseq_root = get_fairseq_root(fairseq_exe=fairseq_python_exe, commit="b768be5b81987364d39a07d1caad2bfe1e956896")
-    fairseq_training_args = dict(
-        save_interval=25,
-        max_epoch=600,
-        max_update=420000,
-        fairseq_root=fairseq_root,
-        fairseq_python_exe=fairseq_python_exe,
-        rqmt={"time": 120, "mem": 12, "cpu": 2, "gpu": num_gpus},
-    )
-
-    # run pre-training
-    exp_name = "monophone_boundary_masking_v1"
-    fairseq_args = get_fairseq_args(num_gpus=num_gpus)
-    fairseq_args["task"]["alignment"] = alignment
-    fairseq_args["model"]["mask_strategy"] = "phoneme"
-    fairseq_args["model"]["mask_length"] = 1
-    fairseq_training_args["fairseq_root"] = fairseq_root
-    fairseq_config = FairseqHydraConfig(fairseq_args)
-    job = FairseqHydraTrainingJob(fairseq_config, **fairseq_training_args)
-    job.add_alias(os.path.join(prefix_name, exp_name, "pretraining"))
-    tk.register_output(f"{prefix_name}/{exp_name}/pretraining/scores.png", job.out_plot_se)
-    return job
-
-
-def run_fairseq_pretraining_phoneme_negatives_other_target_boundary_masking():
-    prefix_name = "experiments/librispeech/librispeech_960_pretraining/wav2vec2/"
-    alignment = get_alignment_hdf()
-    num_gpus = 8
-    fairseq_python_exe = tk.Path("/usr/bin/python3")
-    fairseq_root = get_fairseq_root(fairseq_exe=fairseq_python_exe, commit="b768be5b81987364d39a07d1caad2bfe1e956896")
-    fairseq_training_args = dict(
-        save_interval=25,
-        max_epoch=600,
-        max_update=420000,
-        fairseq_root=fairseq_root,
-        fairseq_python_exe=fairseq_python_exe,
-        rqmt={"time": 120, "mem": 16, "cpu": 2, "gpu": num_gpus},
-    )
-
-    # run pre-training
-    exp_name = "monophone_negatives_other_target_boundary_masking_v1"
-    fairseq_args = get_fairseq_args(num_gpus=num_gpus)
-    fairseq_args["task"]["alignment"] = alignment
-    fairseq_args["model"]["negative_sampling_strategy"] = "other_target"
-    fairseq_args["model"]["mask_strategy"] = "phoneme"
-    fairseq_args["model"]["mask_length"] = 1
-    fairseq_training_args["fairseq_root"] = fairseq_root
-    fairseq_config = FairseqHydraConfig(fairseq_args)
-    job = FairseqHydraTrainingJob(fairseq_config, **fairseq_training_args)
-    job.add_alias(os.path.join(prefix_name, exp_name, "pretraining"))
-    tk.register_output(f"{prefix_name}/{exp_name}/pretraining/scores.png", job.out_plot_se)
-    return job
-
-
-def run_fairseq_pretraining_positive_sampling(num_positives: int = 10):
-    prefix_name = "experiments/librispeech/librispeech_960_pretraining/wav2vec2/"
-    alignment = get_alignment_hdf()
-    num_gpus = 8
-    fairseq_python_exe = tk.Path("/usr/bin/python3")
-    fairseq_root = get_fairseq_root(fairseq_exe=fairseq_python_exe, commit="91b936231c5ebbfd639ccd7e78869d3df45a12bb")
+    fairseq_python_exe = tk.Path("/usr/bin/python3") # maybe add: hash_overwrite="itc_python_launcher_py310_torch"?
+    fairseq_root = get_fairseq_root(fairseq_exe=fairseq_python_exe, commit=commit)
     fairseq_training_args = dict(
         save_interval=25,
         max_epoch=600,
@@ -200,12 +87,14 @@ def run_fairseq_pretraining_positive_sampling(num_positives: int = 10):
         rqmt={"time": 336, "mem": 16, "cpu": 2, "gpu": num_gpus},
     )
 
-    # run pre-training
-    exp_name = f"monophone_positive_sampling_{num_positives}_v1"
+    # generate config
     fairseq_args = get_fairseq_args(num_gpus=num_gpus)
     fairseq_args["task"]["alignment"] = alignment
-    fairseq_args["model"]["num_positives"] = num_positives
+    for k, v in kwargs.items():
+        fairseq_args["model"][k] = v
     fairseq_config = FairseqHydraConfig(fairseq_args)
+
+    # run pretraining
     job = FairseqHydraTrainingJob(fairseq_config, **fairseq_training_args)
     job.add_alias(os.path.join(prefix_name, exp_name, "pretraining"))
     tk.register_output(f"{prefix_name}/{exp_name}/pretraining/scores.png", job.out_plot_se)
@@ -213,11 +102,37 @@ def run_fairseq_pretraining_positive_sampling(num_positives: int = 10):
 
 
 def py():
-    run_fairseq_pretraining_negatives_other_target()
-    run_fairseq_pretraining_negatives_hard()
-    run_fairseq_pretraining_phoneme_boundary_masking()
-    run_fairseq_pretraining_phoneme_negatives_other_target_boundary_masking()
-    run_fairseq_pretraining_positive_sampling(num_positives=5)
-    run_fairseq_pretraining_positive_sampling(num_positives=10)
-    run_fairseq_pretraining_positive_sampling(num_positives=15)
-
+    # negatives other
+    run_fairseq_pretraining(
+        exp_name="monophone_negatives_other_target_v1",
+        commit="1397363c5c0e3c4e3ab620be562730399c852493",
+        negative_sampling_strategy="other_target",
+    )
+    # negatives hard
+    run_fairseq_pretraining(
+        exp_name="monophone_negatives_hard_v1",
+        commit="56acedca3b72c09ec30b7208da0d15ada03d0479",
+        negative_sampling_strategy="hard_negatives",
+    )
+    # boundary_masking
+    run_fairseq_pretraining(
+        exp_name="monophone_boundary_masking_v1",
+        commit="b768be5b81987364d39a07d1caad2bfe1e956896",
+        mask_strategy="phoneme",
+        mask_length=1,
+    )
+    # negatives other + boundary masking
+    run_fairseq_pretraining(
+        exp_name="monophone_negatives_other_target_boundary_masking_v1",
+        commit="b768be5b81987364d39a07d1caad2bfe1e956896",
+        negative_sampling_strategy="other_target",
+        mask_strategy="phoneme",
+        mask_length=1,
+    )
+    # positive sampling
+    for num_positives in [5, 10, 15]:
+        run_fairseq_pretraining(
+            exp_name=f"monophone_positive_sampling_{num_positives}_v1",
+            commit="654cd1e65473615f3355a2576adbaba5f5b549c2",
+            num_positives=num_positives,
+        )


### PR DESCRIPTION
While adding more and more phoneme-based modifications to w2v 2.0 and corresponding pretrain configs, I noticed that the dedicated config file (`config_02_fairseq_phoneme.py`) gets more and more chaotic and especially repetitive - almost all code lines in each `run_fairseq_pretraining_[...]` are repetitive. This is why I tried to merge as much functionality into a single function: `run_fairseq_pretraining`. The differences in the original function can be realized by different function parameters (particularly `commit` and `**kwargs`, where the latter has all w2v model specific configurations). 

The single drawback so far is, that for some pretrain jobs, the hashes changed - I suspect it is because of a different `fairseq_python_exe` (which I now set to `/usr/bin/python3` for every job, some where previously set to some ITC-specific python executable). I am not sure, what the best way to fix this is. I am thinking about adding a further parameter like `python_hash_overwrite`, that can be used to set the hash as needed for that job. Or is it also possible to just change the existing job's hash? 
For that reason I set the PR as a draft for now, this might need some thinking and tinkering.

Edit: And also applied Black on the file