### PR TITLE
Add logging for SpecAugment behaviour

### DIFF
--- a/users/vieting/experiments/switchboard/ctc/feat/network_helpers/specaug_configurable.py
+++ b/users/vieting/experiments/switchboard/ctc/feat/network_helpers/specaug_configurable.py
@@ -187,20 +187,18 @@ def transform(data, network, **config):
         enable_logging = tf.convert_to_tensor(config["enable_logging"], dtype=tf.bool)
 
         def logging_ops():
-
             with tf.control_dependencies([
                 tf.print(
-                "Specaug Log: ",
-                current_epoch,
-                actual_time_mask_max_num,
-                actual_freq_mask_max_num,
-                tf.shape(x)[data.time_dim_axis],
-                sep=", "
-            )
+                    "Specaug Log: ",
+                    current_epoch,
+                    actual_time_mask_max_num,
+                    actual_freq_mask_max_num,
+                    tf.shape(x)[data.time_dim_axis],
+                    sep=", "
+                )
             ]):
                 return tf.identity(x_masked)
-
-        tf.cond(enable_logging, logging_ops, lambda: tf.no_op())
+        x_masked = tf.cond(enable_logging, logging_ops, lambda: tf.identity(x_masked))
 
         x_masked = random_mask(
             x_masked,

--- a/users/vieting/experiments/switchboard/ctc/feat/network_helpers/specaug_configurable.py
+++ b/users/vieting/experiments/switchboard/ctc/feat/network_helpers/specaug_configurable.py
@@ -178,7 +178,7 @@ def transform(data, network, **config):
             total_time_masks_max_frames // time_mask_max_size,
         )
         actual_freq_mask_max_num = tf.minimum(freq_mask_max_num, total_freq_masks_max_size // freq_mask_max_size)
-         
+
         # Check if limits where hit and which one
         time_lower_limit_hit = tf.equal(actual_time_mask_max_num, max_time_num_seq_len)
         time_upper_limit_hit = tf.equal(actual_time_mask_max_num, total_time_masks_max_frames // time_mask_max_size)
@@ -187,17 +187,20 @@ def transform(data, network, **config):
         enable_logging = tf.convert_to_tensor(config["enable_logging"], dtype=tf.bool)
 
         def logging_ops():
-            with tf.control_dependencies([
-                tf.print(
-                    "Specaug Log: ",
-                    current_epoch,
-                    actual_time_mask_max_num,
-                    actual_freq_mask_max_num,
-                    tf.shape(x)[data.time_dim_axis],
-                    sep=", "
-                )
-            ]):
+            with tf.control_dependencies(
+                [
+                    tf.print(
+                        "Specaug Log: ",
+                        current_epoch,
+                        actual_time_mask_max_num,
+                        actual_freq_mask_max_num,
+                        tf.shape(x)[data.time_dim_axis],
+                        sep=", ",
+                    )
+                ]
+            ):
                 return tf.identity(x_masked)
+
         x_masked = tf.cond(enable_logging, logging_ops, lambda: tf.identity(x_masked))
 
         x_masked = random_mask(

--- a/users/vieting/experiments/switchboard/ctc/feat/network_helpers/specaug_configurable.py
+++ b/users/vieting/experiments/switchboard/ctc/feat/network_helpers/specaug_configurable.py
@@ -179,11 +179,6 @@ def transform(data, network, **config):
         )
         actual_freq_mask_max_num = tf.minimum(freq_mask_max_num, total_freq_masks_max_size // freq_mask_max_size)
 
-        # Check if limits where hit and which one
-        time_lower_limit_hit = tf.equal(actual_time_mask_max_num, max_time_num_seq_len)
-        time_upper_limit_hit = tf.equal(actual_time_mask_max_num, total_time_masks_max_frames // time_mask_max_size)
-        freq_limit_hit = tf.equal(actual_freq_mask_max_num, total_freq_masks_max_size // freq_mask_max_size)
-
         enable_logging = tf.convert_to_tensor(config["enable_logging"], dtype=tf.bool)
 
         def logging_ops():
@@ -194,6 +189,7 @@ def transform(data, network, **config):
                         current_epoch,
                         actual_time_mask_max_num,
                         actual_freq_mask_max_num,
+                        max_time_num_seq_len
                         tf.shape(x)[data.time_dim_axis],
                         sep=", ",
                     )

--- a/users/vieting/experiments/switchboard/ctc/feat/network_helpers/specaug_configurable.py
+++ b/users/vieting/experiments/switchboard/ctc/feat/network_helpers/specaug_configurable.py
@@ -176,6 +176,24 @@ def transform(data, network, **config):
             total_time_masks_max_frames // time_mask_max_size,
         )
         actual_freq_mask_max_num = tf.minimum(freq_mask_max_num, total_freq_masks_max_size // freq_mask_max_size)
+         
+        # Check if limits where hit and which one
+        time_lower_limit_hit = tf.equal(actual_time_mask_max_num, max_time_num_seq_len)
+        time_upper_limit_hit = tf.equal(actual_time_mask_max_num, total_time_masks_max_frames // time_mask_max_size)
+
+        freq_limit_hit = tf.equal(actual_freq_mask_max_num, total_freq_masks_max_size // freq_mask_max_size)
+        with tf.control_dependencies([
+            tf.print("--------------------"),
+            tf.print("Lower limit (time):", max_time_num_seq_len),
+            tf.print("Upper limit (time):", total_time_masks_max_frames // time_mask_max_size),
+            tf.print("actual_time_mask_max_num:", actual_time_mask_max_num),
+            tf.print("actual_freq_mask_max_num:", actual_freq_mask_max_num),
+            tf.print(" The total time frames:", tf.shape(x)[data.time_dim_axis]),
+            tf.cond(time_lower_limit_hit, lambda: tf.print("Warning: actual_time_mask_max_num has hit the lower limit!"), lambda: tf.no_op()),
+            tf.cond(time_upper_limit_hit, lambda: tf.print("Warning: actual_time_mask_max_num has hit the upper limit!"), lambda: tf.no_op()),
+            tf.cond(freq_limit_hit, lambda: tf.print("Warning: actual_freq_mask_max_num has hit a limit!"), lambda: tf.no_op()),
+        ]):
+            x_masked = tf.identity(x_masked)
 
         x_masked = random_mask(
             x_masked,

--- a/users/vieting/experiments/switchboard/ctc/feat/network_helpers/specaug_configurable.py
+++ b/users/vieting/experiments/switchboard/ctc/feat/network_helpers/specaug_configurable.py
@@ -189,7 +189,7 @@ def transform(data, network, **config):
                         current_epoch,
                         actual_time_mask_max_num,
                         actual_freq_mask_max_num,
-                        max_time_num_seq_len
+                        max_time_num_seq_len,
                         tf.shape(x)[data.time_dim_axis],
                         sep=", ",
                     )


### PR DESCRIPTION
Add logging to the SpecAugment Code.
It feels a bit like a hack and it fills the returnn log really quick.
TODO: Add a toggle to disable logging before finishing this PR.