### PR TITLE
Allow audio conversion while creating ogg zip from LS960 bliss corpus

### DIFF
--- a/common/datasets/librispeech/corpus.py
+++ b/common/datasets/librispeech/corpus.py
@@ -185,7 +185,7 @@ def get_ogg_zip_dict(
     for name, bliss_corpus in bliss_corpus_dict.items():
         ogg_zip_job = BlissToOggZipJob(
             bliss_corpus,
-            no_conversion=True,
+            no_conversion=False,
             returnn_python_exe=returnn_python_exe,
             returnn_root=returnn_root,
         )


### PR DESCRIPTION
Adapt to https://github.com/rwth-i6/returnn/commit/3f7bd3b9c712c6b92ed7ccd8dd925a595cf73716. With the flag set to `True`, the assertion triggers.